### PR TITLE
Replace supplementary materials background image

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -13,6 +13,7 @@
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
+  <component name="ChangesViewManager" flattened_view="true" show_ignored="false" />
   <component name="CreatePatchCommitExecutor">
     <option name="PATCH_PATH" value="" />
   </component>
@@ -25,9 +26,17 @@
       <file leaf-file-name="index.html" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/index.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="232">
-              <caret line="811" column="16" selection-start-line="811" selection-start-column="16" selection-end-line="811" selection-end-column="16" />
-              <folding />
+            <state vertical-scroll-proportion="0.33252132">
+              <caret line="1320" column="62" selection-start-line="1320" selection-start-column="62" selection-end-line="1320" selection-end-column="62" />
+              <folding>
+                <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+                <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+                <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+                <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+                <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+                <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+                <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -35,7 +44,7 @@
       <file leaf-file-name="params.json" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/params.json">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="0">
+            <state vertical-scroll-proportion="0.0">
               <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
               <folding />
             </state>
@@ -45,7 +54,7 @@
       <file leaf-file-name="stylesheet.css" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="462">
+            <state vertical-scroll-proportion="0.0">
               <caret line="22" column="8" selection-start-line="22" selection-start-column="7" selection-end-line="22" selection-end-column="8" />
               <folding />
             </state>
@@ -55,7 +64,7 @@
       <file leaf-file-name="github-light.css" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="63">
+            <state vertical-scroll-proportion="0.0">
               <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
               <folding />
             </state>
@@ -65,7 +74,7 @@
       <file leaf-file-name="normalize.css" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="1953">
+            <state vertical-scroll-proportion="0.0">
               <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
               <folding />
             </state>
@@ -95,17 +104,14 @@
       </list>
     </option>
   </component>
-  <component name="JsBuildToolGruntFileManager" detection-done="true" sorting="DEFINITION_ORDER" />
-  <component name="JsBuildToolPackageJson" detection-done="true" sorting="DEFINITION_ORDER" />
+  <component name="JsBuildToolGruntFileManager" detection-done="true" />
+  <component name="JsBuildToolPackageJson" detection-done="true" />
   <component name="JsGulpfileManager">
     <detection-done>true</detection-done>
-    <sorting>DEFINITION_ORDER</sorting>
   </component>
   <component name="ProjectFrameBounds">
-    <option name="x" value="156" />
-    <option name="y" value="61" />
-    <option name="width" value="1721" />
-    <option name="height" value="893" />
+    <option name="width" value="1680" />
+    <option name="height" value="1046" />
   </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
@@ -132,8 +138,8 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scratches" />
       <pane id="Scope" />
+      <pane id="Scratches" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -183,9 +189,7 @@
     <configuration default="true" type="DartTestRunConfigurationType" factoryName="Dart Test">
       <method />
     </configuration>
-    <configuration default="true" type="JavaScriptTestRunnerKarma" factoryName="Karma">
-      <config-file value="" />
-      <node-interpreter value="project" />
+    <configuration default="true" type="JavaScriptTestRunnerKarma" factoryName="Karma" config-file="">
       <envs />
       <method />
     </configuration>
@@ -202,7 +206,6 @@
       <method />
     </configuration>
     <configuration default="true" type="js.build_tools.gulp" factoryName="Gulp.js">
-      <node-interpreter>project</node-interpreter>
       <node-options />
       <gulpfile />
       <tasks />
@@ -213,12 +216,10 @@
     <configuration default="true" type="js.build_tools.npm" factoryName="npm">
       <command value="run-script" />
       <scripts />
-      <node-interpreter value="project" />
       <envs />
       <method />
     </configuration>
     <configuration default="true" type="mocha-javascript-test-runner" factoryName="Mocha">
-      <node-interpreter>project</node-interpreter>
       <node-options />
       <working-directory />
       <pass-parent-env>true</pass-parent-env>
@@ -231,9 +232,7 @@
       <method />
     </configuration>
   </component>
-  <component name="ShelveChangesManager" show_recycled="false">
-    <option name="remove_strategy" value="false" />
-  </component>
+  <component name="ShelveChangesManager" show_recycled="false" />
   <component name="SvnConfiguration">
     <configuration />
   </component>
@@ -242,7 +241,6 @@
       <changelist id="966c8e2d-14dd-48aa-b17b-f89e5b7d2cb7" name="Default" comment="" />
       <created>1470250827667</created>
       <option name="number" value="Default" />
-      <option name="presentableId" value="Default" />
       <updated>1470250827667</updated>
       <workItem from="1470250828943" duration="1841000" />
       <workItem from="1470330242060" duration="62000" />
@@ -258,10 +256,10 @@
     <option name="totallyTimeSpent" value="12723000" />
   </component>
   <component name="ToolWindowManager">
-    <frame x="156" y="61" width="1721" height="893" extended-state="1" />
+    <frame x="0" y="0" width="1680" height="1046" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.14193548" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.14181818" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
@@ -303,15 +301,23 @@
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -319,7 +325,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="462">
+        <state vertical-scroll-proportion="0.0">
           <caret line="22" column="8" selection-start-line="22" selection-start-column="7" selection-end-line="22" selection-end-column="8" />
           <folding />
         </state>
@@ -327,7 +333,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="63">
+        <state vertical-scroll-proportion="0.0">
           <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
           <folding />
         </state>
@@ -335,7 +341,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1953">
+        <state vertical-scroll-proportion="0.0">
           <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
           <folding />
         </state>
@@ -343,15 +349,23 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="16800">
-          <caret line="800" column="28" selection-start-line="800" selection-start-column="17" selection-end-line="800" selection-end-column="28" />
-          <folding />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -359,7 +373,55 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="22" column="8" selection-start-line="22" selection-start-column="7" selection-end-line="22" selection-end-column="8" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/index.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="800" column="28" selection-start-line="800" selection-start-column="17" selection-end-line="800" selection-end-column="28" />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/params.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -367,7 +429,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="63">
+        <state vertical-scroll-proportion="0.0">
           <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
           <folding />
         </state>
@@ -375,7 +437,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1953">
+        <state vertical-scroll-proportion="0.0">
           <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
           <folding />
         </state>
@@ -383,15 +445,23 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="16800">
+        <state vertical-scroll-proportion="0.0">
           <caret line="800" column="28" selection-start-line="800" selection-start-column="17" selection-end-line="800" selection-end-column="28" />
-          <folding />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -399,7 +469,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -407,7 +477,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="63">
+        <state vertical-scroll-proportion="0.0">
           <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
           <folding />
         </state>
@@ -415,7 +485,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1953">
+        <state vertical-scroll-proportion="0.0">
           <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
           <folding />
         </state>
@@ -423,15 +493,23 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -439,7 +517,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1197">
+        <state vertical-scroll-proportion="0.0">
           <caret line="57" column="7" selection-start-line="57" selection-start-column="6" selection-end-line="57" selection-end-column="7" />
           <folding />
         </state>
@@ -447,7 +525,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="714">
+        <state vertical-scroll-proportion="0.0">
           <caret line="34" column="22" selection-start-line="34" selection-start-column="20" selection-end-line="34" selection-end-column="22" />
           <folding />
         </state>
@@ -455,7 +533,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1869">
+        <state vertical-scroll-proportion="0.0">
           <caret line="89" column="29" selection-start-line="89" selection-start-column="27" selection-end-line="89" selection-end-column="29" />
           <folding />
         </state>
@@ -463,15 +541,23 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -479,18 +565,15 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="504">
+        <state vertical-scroll-proportion="0.0">
           <caret line="24" column="19" selection-start-line="24" selection-start-column="19" selection-end-line="24" selection-end-column="19" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/github-light.css" />
-    <entry file="file://$PROJECT_DIR$/normalize.css" />
-    <entry file="file://$PROJECT_DIR$/stylesheet.css" />
     <entry file="file://$PROJECT_DIR$/params.json">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
+        <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
@@ -498,7 +581,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/github-light.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="63">
+        <state vertical-scroll-proportion="0.0">
           <caret line="3" column="63" selection-start-line="3" selection-start-column="61" selection-end-line="3" selection-end-column="63" />
           <folding />
         </state>
@@ -506,7 +589,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/normalize.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1953">
+        <state vertical-scroll-proportion="0.0">
           <caret line="93" column="17" selection-start-line="93" selection-start-column="16" selection-end-line="93" selection-end-column="17" />
           <folding />
         </state>
@@ -514,7 +597,7 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/stylesheets/stylesheet.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="462">
+        <state vertical-scroll-proportion="0.0">
           <caret line="22" column="8" selection-start-line="22" selection-start-column="7" selection-end-line="22" selection-end-column="8" />
           <folding />
         </state>
@@ -522,9 +605,17 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="232">
-          <caret line="811" column="16" selection-start-line="811" selection-start-column="16" selection-end-line="811" selection-end-column="16" />
-          <folding />
+        <state vertical-scroll-proportion="0.33252132">
+          <caret line="1320" column="62" selection-start-line="1320" selection-start-column="62" selection-end-line="1320" selection-end-column="62" />
+          <folding>
+            <element signature="n#head#0;n#html#0;n#!!top" expanded="false" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#1;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#p#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#2;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#4;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#14;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+            <element signature="n#style#0;n#a#0;n#td#0;n#tr#0;n#table#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#0;n#div#16;n#div#0;n#div#1;n#div#0;n#section#0;n#div#0;n#section#0;n#div#0;n#div#2;n#body#0;n#html#0;n#!!top" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>

--- a/index.html
+++ b/index.html
@@ -2334,5 +2334,3 @@ title: test
   {% endfor %}
 </ul>
 -->
-
->>>>>>> origin/master

--- a/index.html
+++ b/index.html
@@ -1,1342 +1,2321 @@
-
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0," />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<link rel="shortcut icon" href="https://unite.un.org/profiles/panopoly/themes/unite/favicon.ico" type="image/vnd.microsoft.icon" />
-<meta name="description" content="UN-DESA and partners have developed a suite of tools to address the complex interrelations underlying sustainable development. The website introduces practitioners to these tools, provides and interactive platform for policy analysts, and, to the extent possible, it makes available the data and model codes to promote further research and policy dialogue. This site is collaboratively developed by the Department of Economic and Social Affairs and the Office of Information and Communications Technology." />
-<meta name="abstract" content="UN-DESA and partners have developed a suite of tools to address the complex interrelations underlying sustainable development. The website introduces practitioners to these tools, provides and interactive platform for policy analysts, and, to the extent possible, it makes available the data and model codes to promote further research and policy dialogue." />
-<meta name="generator" content="Drupal 7 (http://drupal.org)" />
-<link rel="canonical" href="https://unite.un.org/analytics/desa/modellingtools" />
-<link rel="shortlink" href="https://unite.un.org/node/666" />
-  <title>Modelling Tools for Sustainable Development | UN-DESA</title>
-  <style>
-@import url("https://unite.un.org/modules/system/system.base.css?o7slkw");
-</style>
-<style>
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.core.min.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_core/css/panopoly-jquery-ui-theme.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.accordion.min.css?o7slkw");
-</style>
-<style>
-@import url("https://unite.un.org/sites/all/modules/ldap/ldap_user/ldap_user.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/calendar/css/calendar_multiday.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/date/date_api/date.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/date/date_popup/themes/datepicker.1.7.css?o7slkw");
-@import url("https://unite.un.org/modules/field/theme/field.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin-navbar.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_core/css/panopoly-dropbutton.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/css/panopoly-magic.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/css/panopoly-modal.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/css/panopoly-featured.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/css/panopoly-accordian.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_widgets/panopoly-widgets.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/views/css/views.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/caption_filter/caption-filter.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/ckeditor/css/ckeditor.css?o7slkw");
-</style>
-<style>
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/ctools/css/ctools.css?o7slkw");
-@import url("https://unite.un.org/sites/all/modules/ldap/ldap_servers/ldap_servers.admin.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/lightbox2/css/lightbox.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/contrib/panels/css/panels.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/plugins/layouts/moscone_flipped/moscone-flipped.css?o7slkw");
-@import url("https://unite.un.org/modules/locale/locale.css?o7slkw");
-</style>
-<link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700" media="all" />
-<link type="text/css" rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" media="all" />
-<style>
-@import url("https://unite.un.org/profiles/panopoly/libraries/superfish/css/superfish.css?o7slkw");
-</style>
-<link type="text/css" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" media="all" />
-<style>
-@import url("https://unite.un.org/profiles/panopoly/themes/bootstrap/css/overrides.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/bootstrap.min.css?o7slkw");
-@import url("https://unite.un.org/profiles/panopoly/themes/unite/css/style.css?o7slkw");
-</style>
-<style>
-@import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_images/panopoly-images.css?o7slkw");
-</style>
-  <!-- HTML5 element support for IE6-8 -->
-  <!--[if lt IE 9]>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0,"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <link rel="shortcut icon" href="https://unite.un.org/profiles/panopoly/themes/unite/favicon.ico"
+          type="image/vnd.microsoft.icon"/>
+    <meta name="description"
+          content="UN-DESA and partners have developed a suite of tools to address the complex interrelations underlying sustainable development. The website introduces practitioners to these tools, provides and interactive platform for policy analysts, and, to the extent possible, it makes available the data and model codes to promote further research and policy dialogue. This site is collaboratively developed by the Department of Economic and Social Affairs and the Office of Information and Communications Technology."/>
+    <meta name="abstract"
+          content="UN-DESA and partners have developed a suite of tools to address the complex interrelations underlying sustainable development. The website introduces practitioners to these tools, provides and interactive platform for policy analysts, and, to the extent possible, it makes available the data and model codes to promote further research and policy dialogue."/>
+    <meta name="generator" content="Drupal 7 (http://drupal.org)"/>
+    <link rel="canonical" href="https://unite.un.org/analytics/desa/modellingtools"/>
+    <link rel="shortlink" href="https://unite.un.org/node/666"/>
+    <title>Modelling Tools for Sustainable Development | UN-DESA</title>
+    <style>
+        @import url("https://unite.un.org/modules/system/system.base.css?o7slkw");
+    </style>
+    <style>
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.core.min.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_core/css/panopoly-jquery-ui-theme.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.accordion.min.css?o7slkw");
+    </style>
+    <style>
+        @import url("https://unite.un.org/sites/all/modules/ldap/ldap_user/ldap_user.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/calendar/css/calendar_multiday.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/date/date_api/date.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/date/date_popup/themes/datepicker.1.7.css?o7slkw");
+        @import url("https://unite.un.org/modules/field/theme/field.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin-navbar.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_core/css/panopoly-dropbutton.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/css/panopoly-magic.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/css/panopoly-modal.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/css/panopoly-featured.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/css/panopoly-accordian.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_widgets/panopoly-widgets.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/views/css/views.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/caption_filter/caption-filter.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/ckeditor/css/ckeditor.css?o7slkw");
+    </style>
+    <style>
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/ctools/css/ctools.css?o7slkw");
+        @import url("https://unite.un.org/sites/all/modules/ldap/ldap_servers/ldap_servers.admin.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/lightbox2/css/lightbox.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/contrib/panels/css/panels.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/plugins/layouts/moscone_flipped/moscone-flipped.css?o7slkw");
+        @import url("https://unite.un.org/modules/locale/locale.css?o7slkw");
+    </style>
+    <link type="text/css" rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700" media="all"/>
+    <link type="text/css" rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css"
+          media="all"/>
+    <style>
+        @import url("https://unite.un.org/profiles/panopoly/libraries/superfish/css/superfish.css?o7slkw");
+    </style>
+    <link type="text/css" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css"
+          media="all"/>
+    <style>
+        @import url("https://unite.un.org/profiles/panopoly/themes/bootstrap/css/overrides.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/bootstrap.min.css?o7slkw");
+        @import url("https://unite.un.org/profiles/panopoly/themes/unite/css/style.css?o7slkw");
+    </style>
+    <style>
+        @import url("https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_images/panopoly-images.css?o7slkw");
+    </style>
+    <!-- HTML5 element support for IE6-8 -->
+    <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-  <![endif]-->
+    <![endif]-->
 
-	
-  <script src="https://unite.un.org/profiles/panopoly/libraries/respondjs/respond.min.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/jquery/1.7/jquery.min.js?v=1.7.2"></script>
-<script src="https://unite.un.org/misc/jquery.once.js?v=1.2"></script>
-<script src="https://unite.un.org/misc/drupal.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.core.min.js?v=1.10.2"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.widget.min.js?v=1.10.2"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.tabs.min.js?v=1.10.2"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.accordion.min.js?v=1.10.2"></script>
-<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/panopoly-magic.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/js/panopoly-accordion.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/caption_filter/js/caption-filter.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/lightbox2/js/lightbox.js?1467163566"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/google_analytics/googleanalytics.js?o7slkw"></script>
-<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "UA-42405966-2", {"cookieDomain":".unite.un.org"});ga("set", "anonymizeIp", true);ga("send", "pageview");</script>
-<script src="https://unite.un.org/profiles/panopoly/libraries/superfish/jquery.hoverIntent.minified.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/libraries/superfish/sfsmallscreen.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/libraries/superfish/supposition.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/libraries/superfish/superfish.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/libraries/superfish/supersubs.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/modules/contrib/superfish/superfish.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/bootstrap.min.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/respond.min.js?o7slkw"></script>
-<script src="https://unite.un.org/profiles/panopoly/themes/unite/js/script.js?o7slkw"></script>
-<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"unite","theme_token":"zEV2tS-hvCrvCFScba2lUUk6VDmjPQRiFDv9XIocTXY","js":{"profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/jquery-ui-tabs-rotate.js":1,"profiles\/panopoly\/themes\/bootstrap\/js\/bootstrap.js":1,"profiles\/panopoly\/libraries\/respondjs\/respond.min.js":1,"profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.accordion.min.js":1,"\/\/netdna.bootstrapcdn.com\/bootstrap\/3.0.2\/js\/bootstrap.min.js":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin.js":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/panopoly-magic.js":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/js\/panopoly-accordion.js":1,"profiles\/panopoly\/modules\/contrib\/caption_filter\/js\/caption-filter.js":1,"profiles\/panopoly\/modules\/contrib\/lightbox2\/js\/lightbox.js":1,"profiles\/panopoly\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"profiles\/panopoly\/libraries\/superfish\/jquery.hoverIntent.minified.js":1,"profiles\/panopoly\/libraries\/superfish\/sfsmallscreen.js":1,"profiles\/panopoly\/libraries\/superfish\/supposition.js":1,"profiles\/panopoly\/libraries\/superfish\/superfish.js":1,"profiles\/panopoly\/libraries\/superfish\/supersubs.js":1,"profiles\/panopoly\/modules\/contrib\/superfish\/superfish.js":1,"profiles\/panopoly\/themes\/unite\/bootstrap\/bootstrap.min.js":1,"profiles\/panopoly\/themes\/unite\/bootstrap\/respond.min.js":1,"profiles\/panopoly\/themes\/unite\/js\/script.js":1},"css":{"modules\/system\/system.base.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"misc\/ui\/jquery.ui.accordion.css":1,"sites\/all\/modules\/ldap\/ldap_user\/ldap_user.css":1,"profiles\/panopoly\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"profiles\/panopoly\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/panopoly\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"modules\/field\/theme\/field.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin-navbar.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_core\/css\/panopoly-dropbutton.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/css\/panopoly-magic.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/css\/panopoly-modal.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/css\/panopoly-featured.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/css\/panopoly-accordian.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/panopoly\/modules\/contrib\/views\/css\/views.css":1,"profiles\/panopoly\/modules\/contrib\/caption_filter\/caption-filter.css":1,"profiles\/panopoly\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"profiles\/panopoly\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/ldap\/ldap_servers\/ldap_servers.admin.css":1,"profiles\/panopoly\/modules\/contrib\/lightbox2\/css\/lightbox.css":1,"profiles\/panopoly\/modules\/contrib\/panels\/css\/panels.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/plugins\/layouts\/moscone_flipped\/moscone-flipped.css":1,"modules\/locale\/locale.css":1,"https:\/\/fonts.googleapis.com\/css?family=Source+Sans+Pro:300,400,600,700":1,"\/\/maxcdn.bootstrapcdn.com\/font-awesome\/4.1.0\/css\/font-awesome.min.css":1,"profiles\/panopoly\/libraries\/superfish\/css\/superfish.css":1,"\/\/netdna.bootstrapcdn.com\/bootstrap\/3.0.2\/css\/bootstrap.min.css":1,"profiles\/panopoly\/themes\/bootstrap\/css\/overrides.css":1,"profiles\/panopoly\/themes\/unite\/bootstrap\/bootstrap.min.css":1,"profiles\/panopoly\/themes\/unite\/css\/style.css":1,"profiles\/panopoly\/modules\/panopoly\/panopoly_images\/panopoly-images.css":1}},"lightbox2":{"rtl":"0","file_path":"\/(\\w\\w\/)public:\/","default_image":"\/profiles\/panopoly\/modules\/contrib\/lightbox2\/images\/brokenimage.jpg","border_size":10,"font_color":"000","box_color":"fff","top_position":"","overlay_opacity":"0.8","overlay_color":"000","disable_close_click":true,"resize_sequence":0,"resize_speed":400,"fade_in_speed":400,"slide_down_speed":600,"use_alt_layout":false,"disable_resize":false,"disable_zoom":false,"force_show_nav":false,"show_caption":true,"loop_items":false,"node_link_text":"View Image Details","node_link_target":false,"image_count":"Image !current of !total","video_count":"Video !current of !total","page_count":"Page !current of !total","lite_press_x_close":"press \u003Ca href=\u0022#\u0022 onclick=\u0022hideLightbox(); return FALSE;\u0022\u003E\u003Ckbd\u003Ex\u003C\/kbd\u003E\u003C\/a\u003E to close","download_link_text":"","enable_login":false,"enable_contact":false,"keys_close":"c x 27","keys_previous":"p 37","keys_next":"n 39","keys_zoom":"z","keys_play_pause":"32","display_image_size":"original","image_node_sizes":"()","trigger_lightbox_classes":"","trigger_lightbox_group_classes":"","trigger_slideshow_classes":"","trigger_lightframe_classes":"","trigger_lightframe_group_classes":"","custom_class_handler":0,"custom_trigger_classes":"","disable_for_gallery_lists":true,"disable_for_acidfree_gallery_lists":true,"enable_acidfree_videos":true,"slideshow_interval":5000,"slideshow_automatic_start":true,"slideshow_automatic_exit":true,"show_play_pause":true,"pause_on_next_click":false,"pause_on_previous_click":true,"loop_slides":false,"iframe_width":600,"iframe_height":400,"iframe_border":1,"enable_video":false},"CToolsModal":{"modalSize":{"type":"scale","width":".9","height":".9","addWidth":0,"addHeight":0,"contentRight":25,"contentBottom":75},"modalOptions":{"opacity":".55","background-color":"#FFF"},"animationSpeed":"fast","modalTheme":"CToolsModalDialog","throbberTheme":"CToolsModalThrobber"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip","trackDomainMode":"1"},"urlIsAjaxTrusted":{"\/analytics\/desa\/modellingtools":true},"superfish":{"1":{"id":"1","sf":{"animation":{"opacity":"show","height":"show"},"speed":"\u0027fast\u0027","autoArrows":true,"dropShadows":true,"disableHI":false},"plugins":{"smallscreen":{"mode":"window_width","addSelected":false,"menuClasses":false,"hyperlinkClasses":false,"title":"Main menu"},"supposition":true,"bgiframe":false,"supersubs":{"minWidth":"12","maxWidth":"27","extraWidth":1}}}},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+
+    <script src="https://unite.un.org/profiles/panopoly/libraries/respondjs/respond.min.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/jquery/1.7/jquery.min.js?v=1.7.2"></script>
+    <script src="https://unite.un.org/misc/jquery.once.js?v=1.2"></script>
+    <script src="https://unite.un.org/misc/drupal.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.core.min.js?v=1.10.2"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.widget.min.js?v=1.10.2"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.tabs.min.js?v=1.10.2"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/jquery_update/replace/ui/ui/minified/jquery.ui.accordion.min.js?v=1.10.2"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_admin/panopoly-admin.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_magic/panopoly-magic.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_theme/js/panopoly-accordion.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/caption_filter/js/caption-filter.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/lightbox2/js/lightbox.js?1467163566"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/google_analytics/googleanalytics.js?o7slkw"></script>
+    <script>(function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        i[r] = i[r] || function () {
+                    (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date();
+        a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+    })(window, document, "script", "//www.google-analytics.com/analytics.js", "ga");
+    ga("create", "UA-42405966-2", {"cookieDomain": ".unite.un.org"});
+    ga("set", "anonymizeIp", true);
+    ga("send", "pageview");</script>
+    <script src="https://unite.un.org/profiles/panopoly/libraries/superfish/jquery.hoverIntent.minified.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/libraries/superfish/sfsmallscreen.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/libraries/superfish/supposition.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/libraries/superfish/superfish.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/libraries/superfish/supersubs.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/modules/contrib/superfish/superfish.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/bootstrap.min.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/themes/unite/bootstrap/respond.min.js?o7slkw"></script>
+    <script src="https://unite.un.org/profiles/panopoly/themes/unite/js/script.js?o7slkw"></script>
+    <script>jQuery.extend(Drupal.settings, {
+        "basePath": "\/",
+        "pathPrefix": "",
+        "ajaxPageState": {
+            "theme": "unite",
+            "theme_token": "zEV2tS-hvCrvCFScba2lUUk6VDmjPQRiFDv9XIocTXY",
+            "js": {
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/panopoly-widgets.js": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/jquery-ui-tabs-rotate.js": 1,
+                "profiles\/panopoly\/themes\/bootstrap\/js\/bootstrap.js": 1,
+                "profiles\/panopoly\/libraries\/respondjs\/respond.min.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js": 1,
+                "misc\/jquery.once.js": 1,
+                "misc\/drupal.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.accordion.min.js": 1,
+                "\/\/netdna.bootstrapcdn.com\/bootstrap\/3.0.2\/js\/bootstrap.min.js": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin.js": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/panopoly-magic.js": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/js\/panopoly-accordion.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/caption_filter\/js\/caption-filter.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/lightbox2\/js\/lightbox.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/google_analytics\/googleanalytics.js": 1,
+                "0": 1,
+                "profiles\/panopoly\/libraries\/superfish\/jquery.hoverIntent.minified.js": 1,
+                "profiles\/panopoly\/libraries\/superfish\/sfsmallscreen.js": 1,
+                "profiles\/panopoly\/libraries\/superfish\/supposition.js": 1,
+                "profiles\/panopoly\/libraries\/superfish\/superfish.js": 1,
+                "profiles\/panopoly\/libraries\/superfish\/supersubs.js": 1,
+                "profiles\/panopoly\/modules\/contrib\/superfish\/superfish.js": 1,
+                "profiles\/panopoly\/themes\/unite\/bootstrap\/bootstrap.min.js": 1,
+                "profiles\/panopoly\/themes\/unite\/bootstrap\/respond.min.js": 1,
+                "profiles\/panopoly\/themes\/unite\/js\/script.js": 1
+            },
+            "css": {
+                "modules\/system\/system.base.css": 1,
+                "misc\/ui\/jquery.ui.core.css": 1,
+                "misc\/ui\/jquery.ui.theme.css": 1,
+                "misc\/ui\/jquery.ui.tabs.css": 1,
+                "misc\/ui\/jquery.ui.accordion.css": 1,
+                "sites\/all\/modules\/ldap\/ldap_user\/ldap_user.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/calendar\/css\/calendar_multiday.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/date\/date_api\/date.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css": 1,
+                "modules\/field\/theme\/field.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_admin\/panopoly-admin-navbar.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_core\/css\/panopoly-dropbutton.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/css\/panopoly-magic.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_magic\/css\/panopoly-modal.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/css\/panopoly-featured.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/css\/panopoly-accordian.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_widgets\/panopoly-widgets.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/views\/css\/views.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/caption_filter\/caption-filter.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/ckeditor\/css\/ckeditor.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/ctools\/css\/ctools.css": 1,
+                "sites\/all\/modules\/ldap\/ldap_servers\/ldap_servers.admin.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/lightbox2\/css\/lightbox.css": 1,
+                "profiles\/panopoly\/modules\/contrib\/panels\/css\/panels.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_theme\/plugins\/layouts\/moscone_flipped\/moscone-flipped.css": 1,
+                "modules\/locale\/locale.css": 1,
+                "https:\/\/fonts.googleapis.com\/css?family=Source+Sans+Pro:300,400,600,700": 1,
+                "\/\/maxcdn.bootstrapcdn.com\/font-awesome\/4.1.0\/css\/font-awesome.min.css": 1,
+                "profiles\/panopoly\/libraries\/superfish\/css\/superfish.css": 1,
+                "\/\/netdna.bootstrapcdn.com\/bootstrap\/3.0.2\/css\/bootstrap.min.css": 1,
+                "profiles\/panopoly\/themes\/bootstrap\/css\/overrides.css": 1,
+                "profiles\/panopoly\/themes\/unite\/bootstrap\/bootstrap.min.css": 1,
+                "profiles\/panopoly\/themes\/unite\/css\/style.css": 1,
+                "profiles\/panopoly\/modules\/panopoly\/panopoly_images\/panopoly-images.css": 1
+            }
+        },
+        "lightbox2": {
+            "rtl": "0",
+            "file_path": "\/(\\w\\w\/)public:\/",
+            "default_image": "\/profiles\/panopoly\/modules\/contrib\/lightbox2\/images\/brokenimage.jpg",
+            "border_size": 10,
+            "font_color": "000",
+            "box_color": "fff",
+            "top_position": "",
+            "overlay_opacity": "0.8",
+            "overlay_color": "000",
+            "disable_close_click": true,
+            "resize_sequence": 0,
+            "resize_speed": 400,
+            "fade_in_speed": 400,
+            "slide_down_speed": 600,
+            "use_alt_layout": false,
+            "disable_resize": false,
+            "disable_zoom": false,
+            "force_show_nav": false,
+            "show_caption": true,
+            "loop_items": false,
+            "node_link_text": "View Image Details",
+            "node_link_target": false,
+            "image_count": "Image !current of !total",
+            "video_count": "Video !current of !total",
+            "page_count": "Page !current of !total",
+            "lite_press_x_close": "press \u003Ca href=\u0022#\u0022 onclick=\u0022hideLightbox(); return FALSE;\u0022\u003E\u003Ckbd\u003Ex\u003C\/kbd\u003E\u003C\/a\u003E to close",
+            "download_link_text": "",
+            "enable_login": false,
+            "enable_contact": false,
+            "keys_close": "c x 27",
+            "keys_previous": "p 37",
+            "keys_next": "n 39",
+            "keys_zoom": "z",
+            "keys_play_pause": "32",
+            "display_image_size": "original",
+            "image_node_sizes": "()",
+            "trigger_lightbox_classes": "",
+            "trigger_lightbox_group_classes": "",
+            "trigger_slideshow_classes": "",
+            "trigger_lightframe_classes": "",
+            "trigger_lightframe_group_classes": "",
+            "custom_class_handler": 0,
+            "custom_trigger_classes": "",
+            "disable_for_gallery_lists": true,
+            "disable_for_acidfree_gallery_lists": true,
+            "enable_acidfree_videos": true,
+            "slideshow_interval": 5000,
+            "slideshow_automatic_start": true,
+            "slideshow_automatic_exit": true,
+            "show_play_pause": true,
+            "pause_on_next_click": false,
+            "pause_on_previous_click": true,
+            "loop_slides": false,
+            "iframe_width": 600,
+            "iframe_height": 400,
+            "iframe_border": 1,
+            "enable_video": false
+        },
+        "CToolsModal": {
+            "modalSize": {
+                "type": "scale",
+                "width": ".9",
+                "height": ".9",
+                "addWidth": 0,
+                "addHeight": 0,
+                "contentRight": 25,
+                "contentBottom": 75
+            },
+            "modalOptions": {"opacity": ".55", "background-color": "#FFF"},
+            "animationSpeed": "fast",
+            "modalTheme": "CToolsModalDialog",
+            "throbberTheme": "CToolsModalThrobber"
+        },
+        "googleanalytics": {
+            "trackOutbound": 1,
+            "trackMailto": 1,
+            "trackDownload": 1,
+            "trackDownloadExtensions": "7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip",
+            "trackDomainMode": "1"
+        },
+        "urlIsAjaxTrusted": {"\/analytics\/desa\/modellingtools": true},
+        "superfish": {
+            "1": {
+                "id": "1",
+                "sf": {
+                    "animation": {"opacity": "show", "height": "show"},
+                    "speed": "\u0027fast\u0027",
+                    "autoArrows": true,
+                    "dropShadows": true,
+                    "disableHI": false
+                },
+                "plugins": {
+                    "smallscreen": {
+                        "mode": "window_width",
+                        "addSelected": false,
+                        "menuClasses": false,
+                        "hyperlinkClasses": false,
+                        "title": "Main menu"
+                    },
+                    "supposition": true,
+                    "bgiframe": false,
+                    "supersubs": {"minWidth": "12", "maxWidth": "27", "extraWidth": 1}
+                }
+            }
+        },
+        "bootstrap": {
+            "anchorsFix": 1,
+            "anchorsSmoothScrolling": 1,
+            "popoverEnabled": 1,
+            "popoverOptions": {
+                "animation": 1,
+                "html": 0,
+                "placement": "right",
+                "selector": "",
+                "trigger": "click",
+                "title": "",
+                "content": "",
+                "delay": 0,
+                "container": "body"
+            },
+            "tooltipEnabled": 1,
+            "tooltipOptions": {
+                "animation": 1,
+                "html": 0,
+                "placement": "auto left",
+                "selector": "",
+                "trigger": "hover focus",
+                "delay": 0,
+                "container": "body"
+            }
+        }
+    });</script>
 </head>
-<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-666 node-type-panopoly-page region-content i18n-en" >
-  <div id="skip-link">
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-666 node-type-panopoly-page region-content i18n-en">
+<div id="skip-link">
     <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
-  </div>
-    <div class="un-top">
+</div>
+<div class="un-top">
 	<span class="welcome-top">
-		<a href="http://www.un.org/" title="United Nations"><img alt="United Nations" src="https://unite.un.org/profiles/panopoly/themes/unite/favicon.ico" /></a> 
+		<a href="http://www.un.org/" title="United Nations"><img alt="United Nations"
+                                                                 src="https://unite.un.org/profiles/panopoly/themes/unite/favicon.ico"/></a>
 		<a href="http://www.un.org/" title="United Nations">Welcome to the United Nations</a>
 	</span>
-		   <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#language-switcher">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      </button>
-      <div class="language-title visible-xs-inline"><a href="javascript:void(0)" data-toggle="collapse" data-target="#language-switcher">Language:</a></div>
-      <div class="navbar-collapse collapse" id="language-switcher">
-          <div class="region region-socialmedia">
-    <section id="block-locale-language" class="block block-locale clearfix">
-
-      
-  <ul class="language-switcher-locale-url"><li class="ar first"><a href="/ar/analytics/desa/modellingtools" class="language-link" xml:lang="ar" lang="ar">العربية</a></li>
-<li class="zh-hans"><a href="/zh/analytics/desa/modellingtools" class="language-link" xml:lang="zh-hans" lang="zh-hans">中文</a></li>
-<li class="en active"><a href="/analytics/desa/modellingtools" class="language-link active" xml:lang="en" lang="en">English</a></li>
-<li class="fr"><a href="/fr/analytics/desa/modellingtools" class="language-link" xml:lang="fr" lang="fr">Français</a></li>
-<li class="ru"><a href="/ru/analytics/desa/modellingtools" class="language-link" xml:lang="ru" lang="ru">Русский</a></li>
-<li class="es last"><a href="/es/analytics/desa/modellingtools" class="language-link" xml:lang="es" lang="es">Español</a></li>
-</ul>
-</section> <!-- /.block -->
-  </div>
-      </div>
-            
-</div>  <!-- un-top -->
-		
-<header id="navbar" class="navbar container navbar-default">
-  <div class="container">
-  
-    <div class="navbar-header">
-	    
-      
-      <div class="navbar-logo">
-                    <a class="logo navbar-btn pull-left" href="/" title="Home">
-            <img src="https://unite.un.org/sites/unite.un.org/files/un_banner_1.png" alt="Home" />
-          </a>
-              
-                    
-                </div>
-      
-        <div class="region region-header">
-    <section id="block-search-form" class="block block-search clearfix">
-
-      
-  <form class="form-search content-search" action="/analytics/desa/modellingtools" method="post" id="search-block-form" accept-charset="UTF-8"><div><div>
-      <h2 class="element-invisible">Search form</h2>
-    <div class="input-group"><input title="Enter the terms you wish to search for." placeholder="Search" class="form-control form-text" type="text" id="edit-search-block-form--2" name="search_block_form" value="" size="15" maxlength="128" /><span class="input-group-btn"><button type="submit" class="btn btn-default"><i class="icon glyphicon glyphicon-search" aria-hidden="true"></i></button></span></div><button class="element-invisible btn btn-primary form-submit" id="edit-submit" name="op" value="Search" type="submit">Search</button>
-<input type="hidden" name="form_build_id" value="form-OQv08Cm18e_NqIzdK0B7Fi_SDWom1FA2zic5iJgohqo" />
-<input type="hidden" name="form_id" value="search_block_form" />
-</div>
-</div></form>
-</section> <!-- /.block -->
-  </div>
-	
-      
-      
-      
-
-      <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#language-switcher">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
-      </button>
+    </button>
+    <div class="language-title visible-xs-inline"><a href="javascript:void(0)" data-toggle="collapse"
+                                                     data-target="#language-switcher">Language:</a></div>
+    <div class="navbar-collapse collapse" id="language-switcher">
+        <div class="region region-socialmedia">
+            <section id="block-locale-language" class="block block-locale clearfix">
+
+
+                <ul class="language-switcher-locale-url">
+                    <li class="ar first"><a href="/ar/analytics/desa/modellingtools" class="language-link" xml:lang="ar"
+                                            lang="ar">العربية</a></li>
+                    <li class="zh-hans"><a href="/zh/analytics/desa/modellingtools" class="language-link"
+                                           xml:lang="zh-hans" lang="zh-hans">中文</a></li>
+                    <li class="en active"><a href="/analytics/desa/modellingtools" class="language-link active"
+                                             xml:lang="en" lang="en">English</a></li>
+                    <li class="fr"><a href="/fr/analytics/desa/modellingtools" class="language-link" xml:lang="fr"
+                                      lang="fr">Français</a></li>
+                    <li class="ru"><a href="/ru/analytics/desa/modellingtools" class="language-link" xml:lang="ru"
+                                      lang="ru">Русский</a></li>
+                    <li class="es last"><a href="/es/analytics/desa/modellingtools" class="language-link" xml:lang="es"
+                                           lang="es">Español</a></li>
+                </ul>
+            </section> <!-- /.block -->
+        </div>
     </div>
 
-          <div class="navbar-collapse collapse">
-      
-      
-        <nav class="navigation">
-                                            <div class="region region-navigation">
-    <section id="block-superfish-1" class="block block-superfish clearfix">
+</div>  <!-- un-top -->
 
-      
-  <ul id="superfish-1" class="menu sf-menu sf-main-menu sf-horizontal sf-style-none sf-total-items-8 sf-parent-items-4 sf-single-items-4"><li id="menu-9144-1" class="first odd sf-item-1 sf-depth-1 sf-total-children-8 sf-parent-children-0 sf-single-children-8 menuparent"><a href="/" title="" class="sf-depth-1 menuparent">App Quicklinks</a><ul><li id="menu-9147-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="https://unite.un.org/connections" title="" class="sf-depth-2">Unite Connections</a></li><li id="menu-9150-1" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a href="https://unite.un.org/docs" title="" class="sf-depth-2">Unite Docs</a></li><li id="menu-9153-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a href="https://unite.un.org/ineedservice" title="" class="sf-depth-2">Unite Self Service (iNeed)</a></li><li id="menu-9168-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a href="https://unite.un.org/apps" title="" class="sf-depth-2">Unite Apps (Portfolio Manager)</a></li><li id="menu-9165-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a href="https://unite.un.org/ideas" title="" class="sf-depth-2">Unite Ideas</a></li><li id="menu-9162-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a href="https://search.un.org" title="" class="sf-depth-2">Unite Search</a></li><li id="menu-9156-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a href="https://inspira.un.org" title="" class="sf-depth-2">inspira</a></li><li id="menu-9159-1" class="last even sf-item-8 sf-depth-2 sf-no-children"><a href="https://selfservice.umoja.un.org" title="" class="sf-depth-2">Umoja Self Service</a></li></ul></li><li id="menu-5104-1" class="middle even sf-item-2 sf-depth-1 sf-total-children-10 sf-parent-children-2 sf-single-children-8 menuparent"><a href="https://unite.un.org/intranet" title="" class="sf-depth-1 menuparent">Resources Quicklinks</a><ul><li id="menu-5809-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="https://unite.un.org/faqs" title="" class="sf-depth-2">ICT FAQs</a></li><li id="menu-9177-1" class="middle even sf-item-2 sf-depth-2 sf-total-children-4 sf-parent-children-0 sf-single-children-4 menuparent"><a href="/bi" class="sf-depth-2 menuparent">Unite Business Intelligence</a><ul><li id="menu-9180-1" class="first odd sf-item-1 sf-depth-3 sf-no-children"><a href="/bi/hr" class="sf-depth-3">Human Resources Reports</a></li><li id="menu-9189-1" class="middle even sf-item-2 sf-depth-3 sf-no-children"><a href="/bi/procurement" class="sf-depth-3">Procurement Reports</a></li><li id="menu-9192-1" class="middle odd sf-item-3 sf-depth-3 sf-no-children"><a href="/bi/supply" class="sf-depth-3">Supply Chain Reports</a></li><li id="menu-9186-1" class="last even sf-item-4 sf-depth-3 sf-no-children"><a href="/bi/travel" class="sf-depth-3">Travel Reports</a></li></ul></li><li id="menu-5144-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a href="/servicedesk" class="sf-depth-2">Unite Service Desk</a></li><li id="menu-5109-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a href="https://iseek.un.org/department/information-security" title="" class="sf-depth-2">Information Security</a></li><li id="menu-6391-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a href="http://unite.un.org/community" title="" class="sf-depth-2">Unite Community</a></li><li id="menu-5114-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a href="https://iseek.un.org/department/training" title="" class="sf-depth-2">ICT Training and Guides</a></li><li id="menu-5119-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a href="https://iseek.un.org/department/policies" title="" class="sf-depth-2">ICT Policies</a></li><li id="menu-5124-1" class="middle even sf-item-8 sf-depth-2 sf-no-children"><a href="https://iseek.un.org/department/standards" title="" class="sf-depth-2">ICT Standards</a></li><li id="menu-5129-1" class="middle odd sf-item-9 sf-depth-2 sf-no-children"><a href="https://iseek.un.org/webpgdept1630_13" title="" class="sf-depth-2">Governance</a></li><li id="menu-9195-1" class="last even sf-item-10 sf-depth-2 sf-total-children-3 sf-parent-children-0 sf-single-children-3 menuparent"><a href="/content/local-quicklinks" class="sf-depth-2 menuparent">Local Quicklinks</a><ul><li id="menu-9198-1" class="first odd sf-item-1 sf-depth-3 sf-no-children"><a href="https://iseek.un.org/oict" title="" class="sf-depth-3">OICT on iSeek</a></li><li id="menu-9201-1" class="middle even sf-item-2 sf-depth-3 sf-no-children"><a href="https://our-intranet.unog.un.org/" title="" class="sf-depth-3">Geneva Intranet</a></li><li id="menu-9204-1" class="last odd sf-item-3 sf-depth-3 sf-no-children"><a href="https://www.unodc.org/intranet/" title="" class="sf-depth-3">Vienna Intranet</a></li></ul></li></ul></li><li id="menu-9174-1" class="middle odd sf-item-3 sf-depth-1 sf-total-children-14 sf-parent-children-0 sf-single-children-14 menuparent"><a href="/services" title="" class="sf-depth-1 menuparent">Our Products</a><ul><li id="menu-3772-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="/services/unite-connections" class="sf-depth-2">Unite Connections</a></li><li id="menu-3769-1" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a href="/services/unite-docs" class="sf-depth-2">Unite Docs</a></li><li id="menu-3763-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a href="/services/unite-drive" class="sf-depth-2">Unite Drive</a></li><li id="menu-3748-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a href="/services/information-security" class="sf-depth-2">Unite InfoSec</a></li><li id="menu-4483-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a href="/services/unite-identity" class="sf-depth-2">Unite Identity</a></li><li id="menu-3757-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a href="/services/unite-self-service" class="sf-depth-2">Unite Self Service</a></li><li id="menu-3751-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a href="/services/unite-ideas" class="sf-depth-2">Unite Ideas</a></li><li id="menu-9068-1" class="middle even sf-item-8 sf-depth-2 sf-no-children"><a href="/services/unite-analytics" class="sf-depth-2">Unite Analytics</a></li><li id="menu-3754-1" class="middle odd sf-item-9 sf-depth-2 sf-no-children"><a href="/services/unite-search" class="sf-depth-2">Unite Search</a></li><li id="menu-9072-1" class="middle even sf-item-10 sf-depth-2 sf-no-children"><a href="/services/unite-open-source" class="sf-depth-2">Unite Open Source</a></li><li id="menu-9076-1" class="middle odd sf-item-11 sf-depth-2 sf-no-children"><a href="/services/unite-labs" class="sf-depth-2">Unite Labs</a></li><li id="menu-8001-1" class="middle even sf-item-12 sf-depth-2 sf-no-children"><a href="/services/fuel" class="sf-depth-2">Fuel Management</a></li><li id="menu-8006-1" class="middle odd sf-item-13 sf-depth-2 sf-no-children"><a href="/services/rations" class="sf-depth-2">Rations Management</a></li><li id="menu-8011-1" class="last even sf-item-14 sf-depth-2 sf-no-children"><a href="/services/equipment" class="sf-depth-2">Contingent Owned Equipment</a></li></ul></li><li id="menu-8205-1" class="middle even sf-item-4 sf-depth-1 sf-no-children"><a href="/news" title="" class="sf-depth-1">News</a></li><li id="menu-8209-1" class="middle odd sf-item-5 sf-depth-1 sf-no-children"><a href="/techevents" title="" class="sf-depth-1">Events</a></li><li id="menu-9171-1" class="middle even sf-item-6 sf-depth-1 sf-no-children"><a href="/content/media" title="" class="sf-depth-1">Multimedia</a></li><li id="menu-3736-1" class="middle odd sf-item-7 sf-depth-1 sf-total-children-2 sf-parent-children-0 sf-single-children-2 menuparent"><a href="/content/about" class="sf-depth-1 menuparent">About</a><ul><li id="menu-3775-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="/content/strategic-programmes" class="sf-depth-2">Strategic Programmes</a></li><li id="menu-3742-1" class="last even sf-item-2 sf-depth-2 sf-no-children"><a href="/content/leadership" class="sf-depth-2">Leadership</a></li></ul></li><li id="menu-3727-1" class="last even sf-item-8 sf-depth-1 sf-no-children"><a href="/" title="" class="sf-depth-1">Home</a></li></ul>
-</section> <!-- /.block -->
-  </div>
-                  </nav>
-      </div>
-      </div>
+<header id="navbar" class="navbar container navbar-default">
+    <div class="container">
+
+        <div class="navbar-header">
+
+
+            <div class="navbar-logo">
+                <a class="logo navbar-btn pull-left" href="/" title="Home">
+                    <img src="https://unite.un.org/sites/unite.un.org/files/un_banner_1.png" alt="Home"/>
+                </a>
+
+
+            </div>
+
+            <div class="region region-header">
+                <section id="block-search-form" class="block block-search clearfix">
+
+
+                    <form class="form-search content-search" action="/analytics/desa/modellingtools" method="post"
+                          id="search-block-form" accept-charset="UTF-8">
+                        <div>
+                            <div>
+                                <h2 class="element-invisible">Search form</h2>
+                                <div class="input-group"><input title="Enter the terms you wish to search for."
+                                                                placeholder="Search" class="form-control form-text"
+                                                                type="text" id="edit-search-block-form--2"
+                                                                name="search_block_form" value="" size="15"
+                                                                maxlength="128"/><span class="input-group-btn"><button
+                                        type="submit" class="btn btn-default"><i class="icon glyphicon glyphicon-search"
+                                                                                 aria-hidden="true"></i></button></span>
+                                </div>
+                                <button class="element-invisible btn btn-primary form-submit" id="edit-submit" name="op"
+                                        value="Search" type="submit">Search
+                                </button>
+                                <input type="hidden" name="form_build_id"
+                                       value="form-OQv08Cm18e_NqIzdK0B7Fi_SDWom1FA2zic5iJgohqo"/>
+                                <input type="hidden" name="form_id" value="search_block_form"/>
+                            </div>
+                        </div>
+                    </form>
+                </section> <!-- /.block -->
+            </div>
+
+
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+        </div>
+
+        <div class="navbar-collapse collapse">
+
+
+            <nav class="navigation">
+                <div class="region region-navigation">
+                    <section id="block-superfish-1" class="block block-superfish clearfix">
+
+
+                        <ul id="superfish-1"
+                            class="menu sf-menu sf-main-menu sf-horizontal sf-style-none sf-total-items-8 sf-parent-items-4 sf-single-items-4">
+                            <li id="menu-9144-1"
+                                class="first odd sf-item-1 sf-depth-1 sf-total-children-8 sf-parent-children-0 sf-single-children-8 menuparent">
+                                <a href="/" title="" class="sf-depth-1 menuparent">App Quicklinks</a>
+                                <ul>
+                                    <li id="menu-9147-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/connections" title="" class="sf-depth-2">Unite
+                                        Connections</a></li>
+                                    <li id="menu-9150-1" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/docs" title="" class="sf-depth-2">Unite Docs</a>
+                                    </li>
+                                    <li id="menu-9153-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/ineedservice" title="" class="sf-depth-2">Unite
+                                        Self Service (iNeed)</a></li>
+                                    <li id="menu-9168-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/apps" title="" class="sf-depth-2">Unite Apps
+                                        (Portfolio Manager)</a></li>
+                                    <li id="menu-9165-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/ideas" title="" class="sf-depth-2">Unite
+                                        Ideas</a></li>
+                                    <li id="menu-9162-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a
+                                            href="https://search.un.org" title="" class="sf-depth-2">Unite Search</a>
+                                    </li>
+                                    <li id="menu-9156-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a
+                                            href="https://inspira.un.org" title="" class="sf-depth-2">inspira</a></li>
+                                    <li id="menu-9159-1" class="last even sf-item-8 sf-depth-2 sf-no-children"><a
+                                            href="https://selfservice.umoja.un.org" title="" class="sf-depth-2">Umoja
+                                        Self Service</a></li>
+                                </ul>
+                            </li>
+                            <li id="menu-5104-1"
+                                class="middle even sf-item-2 sf-depth-1 sf-total-children-10 sf-parent-children-2 sf-single-children-8 menuparent">
+                                <a href="https://unite.un.org/intranet" title="" class="sf-depth-1 menuparent">Resources
+                                    Quicklinks</a>
+                                <ul>
+                                    <li id="menu-5809-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a
+                                            href="https://unite.un.org/faqs" title="" class="sf-depth-2">ICT FAQs</a>
+                                    </li>
+                                    <li id="menu-9177-1"
+                                        class="middle even sf-item-2 sf-depth-2 sf-total-children-4 sf-parent-children-0 sf-single-children-4 menuparent">
+                                        <a href="/bi" class="sf-depth-2 menuparent">Unite Business Intelligence</a>
+                                        <ul>
+                                            <li id="menu-9180-1" class="first odd sf-item-1 sf-depth-3 sf-no-children">
+                                                <a href="/bi/hr" class="sf-depth-3">Human Resources Reports</a></li>
+                                            <li id="menu-9189-1"
+                                                class="middle even sf-item-2 sf-depth-3 sf-no-children"><a
+                                                    href="/bi/procurement" class="sf-depth-3">Procurement Reports</a>
+                                            </li>
+                                            <li id="menu-9192-1" class="middle odd sf-item-3 sf-depth-3 sf-no-children">
+                                                <a href="/bi/supply" class="sf-depth-3">Supply Chain Reports</a></li>
+                                            <li id="menu-9186-1" class="last even sf-item-4 sf-depth-3 sf-no-children">
+                                                <a href="/bi/travel" class="sf-depth-3">Travel Reports</a></li>
+                                        </ul>
+                                    </li>
+                                    <li id="menu-5144-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a
+                                            href="/servicedesk" class="sf-depth-2">Unite Service Desk</a></li>
+                                    <li id="menu-5109-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a
+                                            href="https://iseek.un.org/department/information-security" title=""
+                                            class="sf-depth-2">Information Security</a></li>
+                                    <li id="menu-6391-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a
+                                            href="http://unite.un.org/community" title="" class="sf-depth-2">Unite
+                                        Community</a></li>
+                                    <li id="menu-5114-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a
+                                            href="https://iseek.un.org/department/training" title="" class="sf-depth-2">ICT
+                                        Training and Guides</a></li>
+                                    <li id="menu-5119-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a
+                                            href="https://iseek.un.org/department/policies" title="" class="sf-depth-2">ICT
+                                        Policies</a></li>
+                                    <li id="menu-5124-1" class="middle even sf-item-8 sf-depth-2 sf-no-children"><a
+                                            href="https://iseek.un.org/department/standards" title=""
+                                            class="sf-depth-2">ICT Standards</a></li>
+                                    <li id="menu-5129-1" class="middle odd sf-item-9 sf-depth-2 sf-no-children"><a
+                                            href="https://iseek.un.org/webpgdept1630_13" title="" class="sf-depth-2">Governance</a>
+                                    </li>
+                                    <li id="menu-9195-1"
+                                        class="last even sf-item-10 sf-depth-2 sf-total-children-3 sf-parent-children-0 sf-single-children-3 menuparent">
+                                        <a href="/content/local-quicklinks" class="sf-depth-2 menuparent">Local
+                                            Quicklinks</a>
+                                        <ul>
+                                            <li id="menu-9198-1" class="first odd sf-item-1 sf-depth-3 sf-no-children">
+                                                <a href="https://iseek.un.org/oict" title="" class="sf-depth-3">OICT on
+                                                    iSeek</a></li>
+                                            <li id="menu-9201-1"
+                                                class="middle even sf-item-2 sf-depth-3 sf-no-children"><a
+                                                    href="https://our-intranet.unog.un.org/" title=""
+                                                    class="sf-depth-3">Geneva Intranet</a></li>
+                                            <li id="menu-9204-1" class="last odd sf-item-3 sf-depth-3 sf-no-children"><a
+                                                    href="https://www.unodc.org/intranet/" title="" class="sf-depth-3">Vienna
+                                                Intranet</a></li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li id="menu-9174-1"
+                                class="middle odd sf-item-3 sf-depth-1 sf-total-children-14 sf-parent-children-0 sf-single-children-14 menuparent">
+                                <a href="/services" title="" class="sf-depth-1 menuparent">Our Products</a>
+                                <ul>
+                                    <li id="menu-3772-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-connections" class="sf-depth-2">Unite Connections</a>
+                                    </li>
+                                    <li id="menu-3769-1" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-docs" class="sf-depth-2">Unite Docs</a></li>
+                                    <li id="menu-3763-1" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-drive" class="sf-depth-2">Unite Drive</a></li>
+                                    <li id="menu-3748-1" class="middle even sf-item-4 sf-depth-2 sf-no-children"><a
+                                            href="/services/information-security" class="sf-depth-2">Unite InfoSec</a>
+                                    </li>
+                                    <li id="menu-4483-1" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-identity" class="sf-depth-2">Unite Identity</a></li>
+                                    <li id="menu-3757-1" class="middle even sf-item-6 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-self-service" class="sf-depth-2">Unite Self
+                                        Service</a></li>
+                                    <li id="menu-3751-1" class="middle odd sf-item-7 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-ideas" class="sf-depth-2">Unite Ideas</a></li>
+                                    <li id="menu-9068-1" class="middle even sf-item-8 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-analytics" class="sf-depth-2">Unite Analytics</a></li>
+                                    <li id="menu-3754-1" class="middle odd sf-item-9 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-search" class="sf-depth-2">Unite Search</a></li>
+                                    <li id="menu-9072-1" class="middle even sf-item-10 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-open-source" class="sf-depth-2">Unite Open Source</a>
+                                    </li>
+                                    <li id="menu-9076-1" class="middle odd sf-item-11 sf-depth-2 sf-no-children"><a
+                                            href="/services/unite-labs" class="sf-depth-2">Unite Labs</a></li>
+                                    <li id="menu-8001-1" class="middle even sf-item-12 sf-depth-2 sf-no-children"><a
+                                            href="/services/fuel" class="sf-depth-2">Fuel Management</a></li>
+                                    <li id="menu-8006-1" class="middle odd sf-item-13 sf-depth-2 sf-no-children"><a
+                                            href="/services/rations" class="sf-depth-2">Rations Management</a></li>
+                                    <li id="menu-8011-1" class="last even sf-item-14 sf-depth-2 sf-no-children"><a
+                                            href="/services/equipment" class="sf-depth-2">Contingent Owned Equipment</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li id="menu-8205-1" class="middle even sf-item-4 sf-depth-1 sf-no-children"><a href="/news"
+                                                                                                            title=""
+                                                                                                            class="sf-depth-1">News</a>
+                            </li>
+                            <li id="menu-8209-1" class="middle odd sf-item-5 sf-depth-1 sf-no-children"><a
+                                    href="/techevents" title="" class="sf-depth-1">Events</a></li>
+                            <li id="menu-9171-1" class="middle even sf-item-6 sf-depth-1 sf-no-children"><a
+                                    href="/content/media" title="" class="sf-depth-1">Multimedia</a></li>
+                            <li id="menu-3736-1"
+                                class="middle odd sf-item-7 sf-depth-1 sf-total-children-2 sf-parent-children-0 sf-single-children-2 menuparent">
+                                <a href="/content/about" class="sf-depth-1 menuparent">About</a>
+                                <ul>
+                                    <li id="menu-3775-1" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a
+                                            href="/content/strategic-programmes" class="sf-depth-2">Strategic
+                                        Programmes</a></li>
+                                    <li id="menu-3742-1" class="last even sf-item-2 sf-depth-2 sf-no-children"><a
+                                            href="/content/leadership" class="sf-depth-2">Leadership</a></li>
+                                </ul>
+                            </li>
+                            <li id="menu-3727-1" class="last even sf-item-8 sf-depth-1 sf-no-children"><a href="/"
+                                                                                                          title=""
+                                                                                                          class="sf-depth-1">Home</a>
+                            </li>
+                        </ul>
+                    </section> <!-- /.block -->
+                </div>
+            </nav>
+        </div>
+    </div>
 </header>
 
 
 <div class="main-container container">
 
 
-  <div class="row">
-
-    
-    <section class="col-sm-12">
-            <ol class="breadcrumb"><li class="first">Modelling Tools for Sustainable Development</li>
-<li class="active last">Modelling Tools for Sustainable Development</li>
-</ol>      <a id="main-content"></a>
-                    <h1 class="page-header">Modelling Tools for Sustainable Development</h1>
-                                                          <div class="region region-content">
-    <section id="block-system-main" class="block block-system clearfix">
-
-      
-  
-<div class="panel-display moscone-flipped clearfix container " id="page-page">
-
-  <div class="moscone-container moscone-header clearfix panel-panel row-fluid">
-    <div class="moscone-container-inner moscone-header-inner panel-panel-inner span12">
-      <div class="panel-pane pane-fieldable-panels-pane pane-uuid-dbad8e66-337d-4301-9f58-f13ceb822e54 pane-bundle-text"  >
-  
-      
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><style type="text/css">
-<!--/*--><![CDATA[/* ><!--*/
-body {    
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-    #top-gray{
-        background-image: url(https://unite.un.org/sites/unite.un.org/files/app-desa-header/brandbarbkgd.jpg);
-        background-repeat: repeat-x; 
-    }
-    #top-gray { background-color: #c2c6cf; width:100%;}
-    #top-gray a {
-	   text-decoration: none;
-	   color: #1e1e1e;
-	}
+    <div class="row">
 
 
-    #top-blue { background-color: #070050; width:100%;} 
-    #top-blue a {
-        text-decoration: none;
-        color: #fff;
-    }
+        <section class="col-sm-12">
+            <ol class="breadcrumb">
+                <li class="first">Modelling Tools for Sustainable Development</li>
+                <li class="active last">Modelling Tools for Sustainable Development</li>
+            </ol>
+            <a id="main-content"></a>
+            <h1 class="page-header">Modelling Tools for Sustainable Development</h1>
+            <div class="region region-content">
+                <section id="block-system-main" class="block block-system clearfix">
 
-    #mid-blue {
-        float:left;
-        width:100%;
-        margin:0 auto;
-        background-color: #235f91;
-        display:block;
-    }
-    
-    #mid-blue {
-        background-image: linear-gradient(to bottom, #5684A9 -25%, #235F91 48%, #235F91 100%);
-    }
 
-    #mid-blue > a {
-        display:block;
-        padding:0;
-    }
-    #mid-blue img {
-        margin-left: 20px;
-    }
+                    <div class="panel-display moscone-flipped clearfix container " id="page-page">
 
-    #logo-link{
-        display:block;
-        width:100%;
-        margin:0;
-        padding:0;
-        border:none;
-    }
+                        <div class="moscone-container moscone-header clearfix panel-panel row-fluid">
+                            <div class="moscone-container-inner moscone-header-inner panel-panel-inner span12">
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-dbad8e66-337d-4301-9f58-f13ceb822e54 pane-bundle-text">
 
-    #mid-blue h1, #mid-blue h2 {
-        margin: 0 auto;
-        color: #acc8d7 !important;
-        font-weight: normal;
-        text-align: baseline;
-    }
 
-    #mid-blue h1 {
-        font-size: 1.2em;
-    }
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <style type="text/css">
+                                                            <!-- /*--><![CDATA[/* ><!--*/
+                                                            body {
+                                                                margin: 0 !important;
+                                                                padding: 0 !important;
+                                                            }
 
-    #mid-blue h2 {
-        font-size: 1.5em;
-    }
+                                                            #top-gray {
+                                                                background-image: url(https://unite.un.org/sites/unite.un.org/files/app-desa-header/brandbarbkgd.jpg);
+                                                                background-repeat: repeat-x;
+                                                            }
 
-    #mid-blue h2 abbr {
-        display: none;
-    }
-    
-    #logo-link {
-        color:#acc8d7 !important;
-        display: inline-block;
-    }
-    
-    #desa > span {
-        color:#acc8d7 !important;
-    }
-    
+                                                            #top-gray {
+                                                                background-color: #c2c6cf;
+                                                                width: 100%;
+                                                            }
 
-    .desa-banner {
-        height: 100px;
-        vertical-align:middle;
-        display: inline-block;
-        *display: inline;
-        zoom: 1;
-    }
-    #banner-img{
-         width: 100px;
-         padding: 0;
-    }
-    
-    
+                                                            #top-gray a {
+                                                                text-decoration: none;
+                                                                color: #1e1e1e;
+                                                            }
 
-    @media screen and (max-width: 650px){
-        #mid-blue {
-            text-align: left;
-        }
+                                                            #top-blue {
+                                                                background-color: #070050;
+                                                                width: 100%;
+                                                            }
 
-        #mid-blue img {
-            margin-left: 0;
-        }
+                                                            #top-blue a {
+                                                                text-decoration: none;
+                                                                color: #fff;
+                                                            }
 
-        #mid-blue h2 span {
-            display:none;
-        }
-        #mid-blue h2 abbr {
-            display: inline-block;
-        }
-    }
-    
-    #wrapper-text {
-        position: absolute;
-        top: 25%;
-        padding-left: 10px;
-    }
-    /*--
-    #banner-text {
-        display: inline-block;
-        vertical-align: middle;
-        line-height: normal;
-        align-items: left;
-        align-content: flex-start;
-    }
---*/
-    /* UN70 Anniversary logo */
+                                                            #mid-blue {
+                                                                float: left;
+                                                                width: 100%;
+                                                                margin: 0 auto;
+                                                                background-color: #235f91;
+                                                                display: block;
+                                                            }
 
-    .logo_en > a {
-        background: url("https://unite.un.org/sites/unite.un.org/files/app-desa-header/un70_desa_blue_en.png") no-repeat right center;
-    }
+                                                            #mid-blue {
+                                                                background-image: linear-gradient(to bottom, #5684A9 -25%, #235F91 48%, #235F91 100%);
+                                                            }
 
-    #logo-link-70y {
-        display:block;
-        position:absolute;
-        right:0;
-        top:0;
-        height:100px;
-        width:200px;
-        background:transparent;
-    }
+                                                            #mid-blue > a {
+                                                                display: block;
+                                                                padding: 0;
+                                                            }
 
-    @media screen and (max-width: 750px) {
-        #mid-blue > a {
-            background: none;
-        }
-        #mid-blue  > #logo-link-70y {
-            display:none;
-        }
-    }
+                                                            #mid-blue img {
+                                                                margin-left: 20px;
+                                                            }
 
-    .menu {
-        overflow: hidden;
-        float: left;
-        background-color:#acc8d7;
-        background-image:-webkit-gradient(linear, left top, left bottom, from(#acc8d7), to(#98b4c2));
-        background-image:-webkit-linear-gradient(top, #acc8d7, #98b4c2);
-        background-image:-moz-linear-gradient(top, #acc8d7, #98b4c2);
-        background-image:-ms-linear-gradient(top, #acc8d7, #98b4c2);
-        background-image:-o-linear-gradient(top, #acc8d7, #98b4c2);
-        background-image:linear-gradient(top, #acc8d7, #98b4c2);
-        clear:both;
-        filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#acc8d7, endColorstr=#98b4c2);
-        /*    width: 960px !important;*/
-        height:45px !important;
-        text-align:justify;
-        margin:0 auto;
-        display:block;
-        }
-    
-    .menu a img {
-        /* fixes IE 8 bug where max-width:100% causes the image to be displayed
-        (apparently) as block */
-        max-width: inherit; 
-    }
-    
-    .menu a {
-        border-left:1px solid #585858;
-        color:#235f91;
-        /* display:block; */
-        font-size:13px;
-        font-weight:700;
-        height:45px;
-        width: auto;
-        line-height:45px;
-        margin:0 auto; 
-        /*	padding:0 2.9em; 
-        *padding: 0 1.9em;; // Read by IE7 and earlier versions */
-        padding: 0 24px;
-        *padding: 0 29px; 
-        position:relative;
-        text-decoration:none;
-        /* text-shadow:0 1px 1px #242424; */
-        text-shadow:none;
-        text-align:justify;
-        display: inline-block;
-    }
-    
-    .menu ul li:first-child{
-        border-left:none;
-    }
-    
-    .menu ul li a:hover, .menu li li a:hover {
-        color:#235f91 !important;
-        text-decoration:none;
-    }
+                                                            #logo-link {
+                                                                display: block;
+                                                                width: 100%;
+                                                                margin: 0;
+                                                                padding: 0;
+                                                                border: none;
+                                                            }
 
-    .sub-header-menu ul li a:hover, .sub-header-menu li li a:hover {
-        color:#235f91 !important;
-        text-decoration:none;
-    }
-        
-    #bottom-blue{
-        width:100%;
-        margin:0 auto;
-        padding:0;
-    }
-    #bottom-navigator {
-            width:100%;
-        margin: 0 auto;
-    }
-    #bottom-navigator li {
-        text-transform: uppercase;
-    }
-    
-    .menu a:hover {
-        background-color:#235f91;
-        color:#f0f8ff;
-        background-image:-webkit-gradient(linear, left top, left bottom, from(#3e76b3), to(#235f91));
-        background-image:-webkit-linear-gradient(top, #3e76b3, #235f91);
-        background-image:-moz-linear-gradient(top, #3e76b3, #235f91);
-        background-image:-ms-linear-gradient(top, #3e76b3, #235f91);
-        background-image:-o-linear-gradient(top, #3e76b3, #235f91);
-        background-image:linear-gradient(top, #3e76b3, #235f91);
-        filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#3e76b3, endColorstr=#235f91);
-    }
+                                                            #mid-blue h1, #mid-blue h2 {
+                                                                margin: 0 auto;
+                                                                color: #acc8d7 !important;
+                                                                font-weight: normal;
+                                                                text-align: baseline;
+                                                            }
 
-    .menu, .menu ul {
-        display:block;
-        list-style-type:none;
-        margin:0 auto !important;
-        padding:0 !important;
-    }
+                                                            #mid-blue h1 {
+                                                                font-size: 1.2em;
+                                                            }
 
-    .menu li {
-        border:0;
-        display:inline-block;
-        float:left; 
-        margin:0 auto;
-        padding:0;
-        position:relative;
-        z-index:5;
-        text-transform: uppercase;
-    }  
-    
-    /*navigator bar on different size of screen*/
-    @media screen and (max-width: 900px){
-        .menu a {
-            padding: 0 19px !important;
-        }
-    }
+                                                            #mid-blue h2 {
+                                                                font-size: 1.5em;
+                                                            }
 
-    @media screen and (max-width: 800px){
-        .menu a {
-            padding: 0 15px !important;
-        }
-    }
+                                                            #mid-blue h2 abbr {
+                                                                display: none;
+                                                            }
 
-    @media screen and (max-width: 755px){
-        .menu a {
-            padding: 0 14px !important;
-        }
-    }
+                                                            #logo-link {
+                                                                color: #acc8d7 !important;
+                                                                display: inline-block;
+                                                            }
 
-    @media screen and (max-width: 725px){
-        .menu a {
-            padding: 0 8px !important;
-        }
-    }
+                                                            #desa > span {
+                                                                color: #acc8d7 !important;
+                                                            }
 
-/* other parts */
-    .not-front #block-system-main {
-    padding-top: 0 !important;
-}
+                                                            .desa-banner {
+                                                                height: 100px;
+                                                                vertical-align: middle;
+                                                                display: inline-block;
+                                                                *display: inline;
+                                                                zoom: 1;
+                                                            }
 
-/*--><!]]>*/
-</style><div class="panel-pane pane-fieldable-panels-pane pane-uuid-b8450d2c-ca43-41ac-af9f-db586d5329fd pane-bundle-text">
-<div class="pane-content">
-<div class="fieldable-panels-pane">
-<div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
-<div class="field-items">
-<div class="field-item even">
-<!-- Stack the columns on mobile by making one full-width and the other half-width --><div class="container-fluid row" id="top-gray">
-<div class="col-md-12"><img align="left" height="18" src="https://unite.un.org/sites/unite.un.org/files/app-desa-header/unicon.jpg" width="21" /><a href="http://www.un.org/en/index.shtml">Welcome to the United Nations. It's your world</a></div>
-</div>
-<!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop --><div class="container-fluid row" id="top-blue">
-<div class="col-xs-12 col-md-12"><a href="http://www.un.org/en/development">Development</a></div>
-</div>
-<!-- Columns are always 50% wide, on mobile and desktop --><div class="container-fluid row logo_en" id="mid-blue">
-<div class="row" id="wrapper-img-text">
-<div class="col-xs-1 col-md-1" id="banner-img"><a href="https://www.un.org/development/desa/en/" id="logo-link"><img alt="" class="desa-banner" height="100" src="images/un-logo.png" width="100" /></a></div>
-<div class="desa-banner  col-xs-8 col-md-8" id="banner-text">
-<div id="wrapper-text">
-<h1 id="un"><a href="https://www.un.org/development/desa/en/" id="logo-link">United Nations</a></h1>
-<h2 id="desa"><a href="https://www.un.org/development/desa/en/" id="logo-link"><span>Department of Economic and Social Affairs</span><abbr>DESA</abbr></a></h2>
-</div>
-</div>
-</div>
-<div id="logo-link-70y"> </div>
-</div>
-<div class="container-fluid row" id="bottom-blue">
-<ul class="menu" id="bottom-navigator">
-<li class="menu-item menu-item-type-custom menu-item-object-custom current-menu-item current_page_item menu-item-home menu-item-6730" id="menu-item-6730"><a href="http://www.un.org/development/desa/en/" title="DESA website Homepage">HOME</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6755" id="menu-item-6755"><a href="https://www.un.org/development/desa/en/what-we-do.html" title="DESA’s mandate">ABOUT US</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6756" id="menu-item-6756"><a href="https://www.un.org/development/desa/en/focus-areas.html" title="DESA’s Main areas of focus">IN FOCUS</a></li>
-<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6731" id="menu-item-6731"><a href="http://www.un.org/development/desa/publications/" title="DESA’s latest major publications">PUBLICATIONS</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6761" id="menu-item-6761"><a href="https://www.un.org/development/desa/en/news.html" title="DESA News">LATEST</a></li>
-<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-18173" id="menu-item-18173"><a href="https://www.un.org/development/desa/undesavoice">NEWSLETTER</a></li>
-<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6895" id="menu-item-6895"><a href="http://esango.un.org/irene/desa.html?page=calendarMonthList" title="Calendar of Events">CALENDAR</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6757" id="menu-item-6757"><a href="https://www.un.org/development/desa/en/contact-us.html" title="Contact DESA">CONTACT US</a></li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div></div></div></div>
-  </div>
+                                                            #banner-img {
+                                                                width: 100px;
+                                                                padding: 0;
+                                                            }
 
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-87551600-c971-48ca-a239-bbee45d20d96 pane-bundle-spotlight"  >
-  
-      
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-spotlight-items field-type-panopoly-spotlight field-label-hidden"><div class="field-items"><div class="field-item even"><div class="panopoly-spotlight-buttons-wrapper" data-rotation-time="5000"><ul><li><a href="#panopoly-spotlight-0">1</a></li><li><a href="#panopoly-spotlight-1">2</a></li><li><a href="#panopoly-spotlight-2">3</a></li><li><a href="#panopoly-spotlight-3">4</a></li><li><a href="#panopoly-spotlight-4">5</a></li></ul><div class="panopoly-spotlight-function-buttons"><a href="#" class="panopoly-spotlight-pause-play">Pause</a></div></div><div id="panopoly-spotlight-0" class="panopoly-spotlight"><img class="panopoly-image-spotlight" src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/modelingbanner_v2_19.jpg?itok=TTZaPk87" width="960" height="560" alt="DESA Modelling Tols" /><div class="panopoly-spotlight-wrapper"></div></div></div><div class="field-item odd"><div id="panopoly-spotlight-1" class="panopoly-spotlight"><a href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img class="panopoly-image-spotlight" src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/fuel_banner_7.jpg?itok=gaDM2N91" width="960" height="560" alt="Fuel Tax and Development" /></a><div class="panopoly-spotlight-wrapper"><h3 class="panopoly-spotlight-label"><a href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html">Link</a></h3></div></div></div><div class="field-item even"><div id="panopoly-spotlight-2" class="panopoly-spotlight"><a href="http://un-desa-modelling.github.io/Electrification_Paths/index.html"><img class="panopoly-image-spotlight" src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/electrification_banner_22.jpg?itok=OiPXIynP" width="960" height="560" alt="Electrification Paths" /></a><div class="panopoly-spotlight-wrapper"><h3 class="panopoly-spotlight-label"><a href="http://un-desa-modelling.github.io/Electrification_Paths/index.html">Link</a></h3></div></div></div><div class="field-item odd"><div id="panopoly-spotlight-3" class="panopoly-spotlight"><a href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html"><img class="panopoly-image-spotlight" src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/climate_banner_5.jpg?itok=oEvjHsk5" width="960" height="560" alt="Global CLEWS" /></a><div class="panopoly-spotlight-wrapper"><h3 class="panopoly-spotlight-label"><a href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html">Link</a></h3></div></div></div><div class="field-item even"><div id="panopoly-spotlight-4" class="panopoly-spotlight"><img class="panopoly-image-spotlight" src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/electricity_banner_2.jpg?itok=IC1eplA1" width="960" height="560" alt="" /><div class="panopoly-spotlight-wrapper"></div></div></div></div></div></div>
-  </div>
+                                                            @media screen and (max-width: 650px) {
+                                                                #mid-blue {
+                                                                    text-align: left;
+                                                                }
 
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-6cc96752-c9ae-4589-bf2e-7fd28cb15d7b pane-bundle-text"  >
-  
-      
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="field-item even">
-<h1>Modelling Tools for Sustainable Development Policies</h1>
-<p>In their quest for sustainable development countries confront the need to harmonise policies in the economic, social and environmental dimensions. In doing so, it is critical to identify the inter-linkages that influence trade-offs and synergies across these dimensions. UN-DESA and partners have developed a suite of tools to address the complex interrelations underlying sustainable development. The website introduces practitioners to these tools, provides and interactive platform for policy analysts, and, to the extent possible, it makes available the data and model codes to promote further research and policy dialogue.
-</p>
-<p><nav><br />
-<ul class="pager">
-<li><a href="#economy">Economy</a></li>
-<li><a href="#social">Social</a></li>
-<li><a href="#environmental">Environment</a></li>
-</ul>
-<p></nav></div>
-</div></div></div></div>
-  </div>
+                                                                #mid-blue img {
+                                                                    margin-left: 0;
+                                                                }
 
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-node-links link-wrapper"  >
-  
-      
-  
-  <div class="pane-content">
-      </div>
+                                                                #mid-blue h2 span {
+                                                                    display: none;
+                                                                }
 
-  
-  </div>
+                                                                #mid-blue h2 abbr {
+                                                                    display: inline-block;
+                                                                }
+                                                            }
+
+                                                            #wrapper-text {
+                                                                position: absolute;
+                                                                top: 25%;
+                                                                padding-left: 10px;
+                                                            }
+
+                                                            /*--
+                                                            #banner-text {
+                                                                display: inline-block;
+                                                                vertical-align: middle;
+                                                                line-height: normal;
+                                                                align-items: left;
+                                                                align-content: flex-start;
+                                                            }
+                                                        --*/
+                                                            /* UN70 Anniversary logo */
+
+                                                            .logo_en > a {
+                                                                background: url("https://unite.un.org/sites/unite.un.org/files/app-desa-header/un70_desa_blue_en.png") no-repeat right center;
+                                                            }
+
+                                                            #logo-link-70y {
+                                                                display: block;
+                                                                position: absolute;
+                                                                right: 0;
+                                                                top: 0;
+                                                                height: 100px;
+                                                                width: 200px;
+                                                                background: transparent;
+                                                            }
+
+                                                            @media screen and (max-width: 750px) {
+                                                                #mid-blue > a {
+                                                                    background: none;
+                                                                }
+
+                                                                #mid-blue > #logo-link-70y {
+                                                                    display: none;
+                                                                }
+                                                            }
+
+                                                            .menu {
+                                                                overflow: hidden;
+                                                                float: left;
+                                                                background-color: #acc8d7;
+                                                                background-image: -webkit-gradient(linear, left top, left bottom, from(#acc8d7), to(#98b4c2));
+                                                                background-image: -webkit-linear-gradient(top, #acc8d7, #98b4c2);
+                                                                background-image: -moz-linear-gradient(top, #acc8d7, #98b4c2);
+                                                                background-image: -ms-linear-gradient(top, #acc8d7, #98b4c2);
+                                                                background-image: -o-linear-gradient(top, #acc8d7, #98b4c2);
+                                                                background-image: linear-gradient(top, #acc8d7, #98b4c2);
+                                                                clear: both;
+                                                                filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#acc8d7, endColorstr=#98b4c2);
+                                                                /*    width: 960px !important;*/
+                                                                height: 45px !important;
+                                                                text-align: justify;
+                                                                margin: 0 auto;
+                                                                display: block;
+                                                            }
+
+                                                            .menu a img {
+                                                                /* fixes IE 8 bug where max-width:100% causes the image to be displayed
+                                                                (apparently) as block */
+                                                                max-width: inherit;
+                                                            }
+
+                                                            .menu a {
+                                                                border-left: 1px solid #585858;
+                                                                color: #235f91;
+                                                                /* display:block; */
+                                                                font-size: 13px;
+                                                                font-weight: 700;
+                                                                height: 45px;
+                                                                width: auto;
+                                                                line-height: 45px;
+                                                                margin: 0 auto;
+                                                                /*	padding:0 2.9em;
+                                                                *padding: 0 1.9em;; // Read by IE7 and earlier versions */
+                                                                padding: 0 24px;
+                                                                *padding: 0 29px;
+                                                                position: relative;
+                                                                text-decoration: none;
+                                                                /* text-shadow:0 1px 1px #242424; */
+                                                                text-shadow: none;
+                                                                text-align: justify;
+                                                                display: inline-block;
+                                                            }
+
+                                                            .menu ul li:first-child {
+                                                                border-left: none;
+                                                            }
+
+                                                            .menu ul li a:hover, .menu li li a:hover {
+                                                                color: #235f91 !important;
+                                                                text-decoration: none;
+                                                            }
+
+                                                            .sub-header-menu ul li a:hover, .sub-header-menu li li a:hover {
+                                                                color: #235f91 !important;
+                                                                text-decoration: none;
+                                                            }
+
+                                                            #bottom-blue {
+                                                                width: 100%;
+                                                                margin: 0 auto;
+                                                                padding: 0;
+                                                            }
+
+                                                            #bottom-navigator {
+                                                                width: 100%;
+                                                                margin: 0 auto;
+                                                            }
+
+                                                            #bottom-navigator li {
+                                                                text-transform: uppercase;
+                                                            }
+
+                                                            .menu a:hover {
+                                                                background-color: #235f91;
+                                                                color: #f0f8ff;
+                                                                background-image: -webkit-gradient(linear, left top, left bottom, from(#3e76b3), to(#235f91));
+                                                                background-image: -webkit-linear-gradient(top, #3e76b3, #235f91);
+                                                                background-image: -moz-linear-gradient(top, #3e76b3, #235f91);
+                                                                background-image: -ms-linear-gradient(top, #3e76b3, #235f91);
+                                                                background-image: -o-linear-gradient(top, #3e76b3, #235f91);
+                                                                background-image: linear-gradient(top, #3e76b3, #235f91);
+                                                                filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#3e76b3, endColorstr=#235f91);
+                                                            }
+
+                                                            .menu, .menu ul {
+                                                                display: block;
+                                                                list-style-type: none;
+                                                                margin: 0 auto !important;
+                                                                padding: 0 !important;
+                                                            }
+
+                                                            .menu li {
+                                                                border: 0;
+                                                                display: inline-block;
+                                                                float: left;
+                                                                margin: 0 auto;
+                                                                padding: 0;
+                                                                position: relative;
+                                                                z-index: 5;
+                                                                text-transform: uppercase;
+                                                            }
+
+                                                            /*navigator bar on different size of screen*/
+                                                            @media screen and (max-width: 900px) {
+                                                                .menu a {
+                                                                    padding: 0 19px !important;
+                                                                }
+                                                            }
+
+                                                            @media screen and (max-width: 800px) {
+                                                                .menu a {
+                                                                    padding: 0 15px !important;
+                                                                }
+                                                            }
+
+                                                            @media screen and (max-width: 755px) {
+                                                                .menu a {
+                                                                    padding: 0 14px !important;
+                                                                }
+                                                            }
+
+                                                            @media screen and (max-width: 725px) {
+                                                                .menu a {
+                                                                    padding: 0 8px !important;
+                                                                }
+                                                            }
+
+                                                            /* other parts */
+                                                            .not-front #block-system-main {
+                                                                padding-top: 0 !important;
+                                                            }
+
+                                                            /*--><!]]>*/
+                                                        </style>
+                                                        <div class="panel-pane pane-fieldable-panels-pane pane-uuid-b8450d2c-ca43-41ac-af9f-db586d5329fd pane-bundle-text">
+                                                            <div class="pane-content">
+                                                                <div class="fieldable-panels-pane">
+                                                                    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                                        <div class="field-items">
+                                                                            <div class="field-item even">
+                                                                                <!-- Stack the columns on mobile by making one full-width and the other half-width -->
+                                                                                <div class="container-fluid row"
+                                                                                     id="top-gray">
+                                                                                    <div class="col-md-12"><img
+                                                                                            align="left" height="18"
+                                                                                            src="https://unite.un.org/sites/unite.un.org/files/app-desa-header/unicon.jpg"
+                                                                                            width="21"/><a
+                                                                                            href="http://www.un.org/en/index.shtml">Welcome
+                                                                                        to the United Nations. It's your
+                                                                                        world</a></div>
+                                                                                </div>
+                                                                                <!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
+                                                                                <div class="container-fluid row"
+                                                                                     id="top-blue">
+                                                                                    <div class="col-xs-12 col-md-12"><a
+                                                                                            href="http://www.un.org/en/development">Development</a>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <!-- Columns are always 50% wide, on mobile and desktop -->
+                                                                                <div class="container-fluid row logo_en"
+                                                                                     id="mid-blue">
+                                                                                    <div class="row"
+                                                                                         id="wrapper-img-text">
+                                                                                        <div class="col-xs-1 col-md-1"
+                                                                                             id="banner-img"><a
+                                                                                                href="https://www.un.org/development/desa/en/"
+                                                                                                id="logo-link"><img
+                                                                                                alt=""
+                                                                                                class="desa-banner"
+                                                                                                height="100"
+                                                                                                src="images/un-logo.png"
+                                                                                                width="100"/></a></div>
+                                                                                        <div class="desa-banner  col-xs-8 col-md-8"
+                                                                                             id="banner-text">
+                                                                                            <div id="wrapper-text">
+                                                                                                <h1 id="un"><a
+                                                                                                        href="https://www.un.org/development/desa/en/"
+                                                                                                        id="logo-link">United
+                                                                                                    Nations</a></h1>
+                                                                                                <h2 id="desa"><a
+                                                                                                        href="https://www.un.org/development/desa/en/"
+                                                                                                        id="logo-link"><span>Department of Economic and Social Affairs</span><abbr>DESA</abbr></a>
+                                                                                                </h2>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div id="logo-link-70y"></div>
+                                                                                </div>
+                                                                                <div class="container-fluid row"
+                                                                                     id="bottom-blue">
+                                                                                    <ul class="menu"
+                                                                                        id="bottom-navigator">
+                                                                                        <li class="menu-item menu-item-type-custom menu-item-object-custom current-menu-item current_page_item menu-item-home menu-item-6730"
+                                                                                            id="menu-item-6730"><a
+                                                                                                href="http://www.un.org/development/desa/en/"
+                                                                                                title="DESA website Homepage">HOME</a>
+                                                                                        </li>
+                                                                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6755"
+                                                                                            id="menu-item-6755"><a
+                                                                                                href="https://www.un.org/development/desa/en/what-we-do.html"
+                                                                                                title="DESA’s mandate">ABOUT
+                                                                                            US</a></li>
+                                                                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6756"
+                                                                                            id="menu-item-6756"><a
+                                                                                                href="https://www.un.org/development/desa/en/focus-areas.html"
+                                                                                                title="DESA’s Main areas of focus">IN
+                                                                                            FOCUS</a></li>
+                                                                                        <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6731"
+                                                                                            id="menu-item-6731"><a
+                                                                                                href="http://www.un.org/development/desa/publications/"
+                                                                                                title="DESA’s latest major publications">PUBLICATIONS</a>
+                                                                                        </li>
+                                                                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6761"
+                                                                                            id="menu-item-6761"><a
+                                                                                                href="https://www.un.org/development/desa/en/news.html"
+                                                                                                title="DESA News">LATEST</a>
+                                                                                        </li>
+                                                                                        <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-18173"
+                                                                                            id="menu-item-18173"><a
+                                                                                                href="https://www.un.org/development/desa/undesavoice">NEWSLETTER</a>
+                                                                                        </li>
+                                                                                        <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6895"
+                                                                                            id="menu-item-6895"><a
+                                                                                                href="http://esango.un.org/irene/desa.html?page=calendarMonthList"
+                                                                                                title="Calendar of Events">CALENDAR</a>
+                                                                                        </li>
+                                                                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6757"
+                                                                                            id="menu-item-6757"><a
+                                                                                                href="https://www.un.org/development/desa/en/contact-us.html"
+                                                                                                title="Contact DESA">CONTACT
+                                                                                            US</a></li>
+                                                                                    </ul>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-87551600-c971-48ca-a239-bbee45d20d96 pane-bundle-spotlight">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-spotlight-items field-type-panopoly-spotlight field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="panopoly-spotlight-buttons-wrapper"
+                                                             data-rotation-time="5000">
+                                                            <ul>
+                                                                <li><a href="#panopoly-spotlight-0">1</a></li>
+                                                                <li><a href="#panopoly-spotlight-1">2</a></li>
+                                                                <li><a href="#panopoly-spotlight-2">3</a></li>
+                                                                <li><a href="#panopoly-spotlight-3">4</a></li>
+                                                                <li><a href="#panopoly-spotlight-4">5</a></li>
+                                                            </ul>
+                                                            <div class="panopoly-spotlight-function-buttons"><a href="#"
+                                                                                                                class="panopoly-spotlight-pause-play">Pause</a>
+                                                            </div>
+                                                        </div>
+                                                        <div id="panopoly-spotlight-0" class="panopoly-spotlight"><img
+                                                                class="panopoly-image-spotlight"
+                                                                src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/modelingbanner_v2_19.jpg?itok=TTZaPk87"
+                                                                width="960" height="560" alt="DESA Modelling Tols"/>
+                                                            <div class="panopoly-spotlight-wrapper"></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="field-item odd">
+                                                        <div id="panopoly-spotlight-1" class="panopoly-spotlight"><a
+                                                                href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img
+                                                                class="panopoly-image-spotlight"
+                                                                src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/fuel_banner_7.jpg?itok=gaDM2N91"
+                                                                width="960" height="560"
+                                                                alt="Fuel Tax and Development"/></a>
+                                                            <div class="panopoly-spotlight-wrapper"><h3
+                                                                    class="panopoly-spotlight-label"><a
+                                                                    href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html">Link</a>
+                                                            </h3></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="field-item even">
+                                                        <div id="panopoly-spotlight-2" class="panopoly-spotlight"><a
+                                                                href="http://un-desa-modelling.github.io/Electrification_Paths/index.html"><img
+                                                                class="panopoly-image-spotlight"
+                                                                src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/electrification_banner_22.jpg?itok=OiPXIynP"
+                                                                width="960" height="560"
+                                                                alt="Electrification Paths"/></a>
+                                                            <div class="panopoly-spotlight-wrapper"><h3
+                                                                    class="panopoly-spotlight-label"><a
+                                                                    href="http://un-desa-modelling.github.io/Electrification_Paths/index.html">Link</a>
+                                                            </h3></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="field-item odd">
+                                                        <div id="panopoly-spotlight-3" class="panopoly-spotlight"><a
+                                                                href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html"><img
+                                                                class="panopoly-image-spotlight"
+                                                                src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/climate_banner_5.jpg?itok=oEvjHsk5"
+                                                                width="960" height="560" alt="Global CLEWS"/></a>
+                                                            <div class="panopoly-spotlight-wrapper"><h3
+                                                                    class="panopoly-spotlight-label"><a
+                                                                    href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html">Link</a>
+                                                            </h3></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="field-item even">
+                                                        <div id="panopoly-spotlight-4" class="panopoly-spotlight"><img
+                                                                class="panopoly-image-spotlight"
+                                                                src="https://unite.un.org/sites/unite.un.org/files/styles/panopoly_image_spotlight/public/general/electricity_banner_2.jpg?itok=IC1eplA1"
+                                                                width="960" height="560" alt=""/>
+                                                            <div class="panopoly-spotlight-wrapper"></div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-6cc96752-c9ae-4589-bf2e-7fd28cb15d7b pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="field-item even">
+                                                            <h1>Modelling Tools for Sustainable Development
+                                                                Policies</h1>
+                                                            <p>In their quest for sustainable development countries
+                                                                confront the need to harmonise policies in the economic,
+                                                                social and environmental dimensions. In doing so, it is
+                                                                critical to identify the inter-linkages that influence
+                                                                trade-offs and synergies across these dimensions.
+                                                                UN-DESA and partners have developed a suite of tools to
+                                                                address the complex interrelations underlying
+                                                                sustainable development. The website introduces
+                                                                practitioners to these tools, provides and interactive
+                                                                platform for policy analysts, and, to the extent
+                                                                possible, it makes available the data and model codes to
+                                                                promote further research and policy dialogue.
+                                                            </p>
+                                                            <p>
+                                                                <nav><br/>
+                                                                    <ul class="pager">
+                                                                        <li><a href="#economy">Economy</a></li>
+                                                                        <li><a href="#social">Social</a></li>
+                                                                        <li><a href="#environmental">Environment</a>
+                                                                        </li>
+                                                                    </ul>
+                                                            <p></nav></div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-node-links link-wrapper">
+
+
+                                    <div class="pane-content">
+                                    </div>
+
+
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="moscone-flipped-container moscone-flipped-column-content clearfix row-fluid">
+                            <div class="moscone-flipped-column-content-region moscone-flipped-content panel-panel span9">
+                                <div class="moscone-flipped-column-content-region-inner moscone-flipped-content-inner panel-panel-inner">
+                                    <div class="panel-pane pane-fieldable-panels-pane pane-uuid-d902456b-f917-480b-8578-46d26ee9105d pane-bundle-text">
+
+                                        <h2 class="pane-title">
+                                            Economy </h2>
+
+
+                                        <div class="pane-content">
+                                            <div class="fieldable-panels-pane">
+                                                <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                    <div class="field-items">
+                                                        <div class="field-item even">
+                                                            <div class="jumbotron" id="economy">
+                                                                <p>Assessing the economic impact of policies and
+                                                                    shocks.</p>
+                                                                <h2>Economy-wide modelling</h2>
+                                                                <p>Development policy must address the way policies and
+                                                                    economic shocks affect multiple variables such as
+                                                                    public budgets, the external sector, economic
+                                                                    activity and employment in sectors, poverty and
+                                                                    inequality. Economy-wide models are useful tools to
+                                                                    investigate these effects.</p>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+
+                                    </div>
+                                    <div class="panel-separator"></div>
+                                    <div class="panel-pane pane-fieldable-panels-pane pane-uuid-38440fa1-db36-4da9-bcd7-b263be56ff1e pane-bundle-text">
+
+
+                                        <div class="pane-content">
+                                            <div class="fieldable-panels-pane">
+                                                <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                    <div class="field-items">
+                                                        <div class="field-item even">
+                                                            <div class="row">
+
+                                                                <!--<a class="thumbnail" style="margin:auto;" href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img alt="..."  height="560" width="960" src="images/fuel_banner_6.jpg" /></a>--></div>
+                                                            <div class="col-xs-4" align="left">
+                                                                <h2 style="margin-bottom: 10px;margin-top: 20px">Fuel
+                                                                    Tax and Development</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:47px"
+                                                                   align="justify">A simulation of a fuel tax, a proxy
+                                                                    for a carbon tax, in three developing countries
+                                                                    shows differential impacts on GDP and in a set of
+                                                                    key social indicators. Results suggest impacts
+                                                                    depend not only on how the newly tax revenue is
+                                                                    recycled back to the economy, but also on how
+                                                                    differences in structural factors condition
+                                                                    responses in countries. Results confirm that policy
+                                                                    choices must be assessed on the basis of the
+                                                                    specific characteristics and objectives of each
+                                                                    country and that policies are not easily
+                                                                    transferable across countries.</p>
+                                                                <table>
+                                                                    <tr>
+                                                                        <td>
+                                                                            <a style="margin-right: 2px"
+                                                                               class="btn btn-primary btn-default active"
+                                                                               href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"
+                                                                               role="button">Explore</a>
+                                                                        </td>
+                                                                        <td>
+                                                                            <a class="btn btn-default active"
+                                                                               href="https://github.com/UN-DESA-Modelling/Fuel_Tax_and_Development"
+                                                                               role="button">Supplementary Materials</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/fuel_banner_6.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-89dc2c29-1407-419d-8611-619e96e16ce1 pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Universal Access to Electricity</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:50px"
+                                                                   align="justify">Providing universal access to
+                                                                    electricity by 2030 poses challenges to many
+                                                                    countries and calls for a careful selection of
+                                                                    technologies. Using open geo-spatial data this model
+                                                                    estimates the mix of technologies that will provide
+                                                                    universal access at the lowest cost. The model
+                                                                    assesses ten scenarios defined by two prices for
+                                                                    diesel and five consumption levels. Results for 44
+                                                                    African countries suggest that GRID connections
+                                                                    could supply up to 76 percent of the electricity
+                                                                    needs of the population in some scenarios. Other
+                                                                    scenarios give preference to small scale renewable
+                                                                    sources, which could supply up to 41 percent of
+                                                                    electricity needs. The investment cost to reach
+                                                                    universality averages around 350 US dollars per
+                                                                    person, but it can add to 1,000 US dollars and more
+                                                                    per person in several countries.</p>
+                                                                <table>
+                                                                    <tr>
+                                                                        <td>
+                                                                            <a class="btn btn-primary btn-default active"
+                                                                               href="http://un-desa-modelling.github.io/Electrification_Paths/index.html"
+                                                                               role="button" style="margin-right: 2px"
+                                                                               type="image">Explore</a>
+                                                                        </td>
+                                                                        <td>
+                                                                            <a class="btn btn-default pull-right active"
+                                                                               href="https://github.com/UN-DESA-Modelling/Electrification_Paths"
+                                                                               role="button">Supplementary Materials</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="http://un-desa-modelling.github.io/Electrification_Paths/index.html"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/electrification_banner_19.jpg"
+                                                                    width="960"/></a></div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-e24f16eb-02ab-42b8-9a13-0a040422255a pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Atlantis, Integrated Systems Analysis of Energy</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:25px"
+                                                                   align="justify">Building local energy-planning
+                                                                    capacity in countries can greatly benefit from an
+                                                                    open, accessible, transferable, yet powerful
+                                                                    modelling package. UN DESA, in partnership with
+                                                                    KTH-dESA, has piloted capacity development in
+                                                                    selected countries to support country efforts in
+                                                                    medium-long term energy planning and it is now
+                                                                    initiating projects in new countries. These projects
+                                                                    preferentially use the Open Source Energy Modelling
+                                                                    System model (OSeMOSYS), a powerful yet open,
+                                                                    flexible and transferable tool. To further
+                                                                    facilitate capacity development and model
+                                                                    improvement, UN DESA and KTH-dESA have developed a
+                                                                    browser based interface for OSeMOSYS, the Model
+                                                                    Management Infrastructure (MoManI). MoManI can
+                                                                    provide development and energy planners with the
+                                                                    tools required to construct models, explore
+                                                                    scenarios and visualize results.</p>
+                                                                <table>
+                                                                    <tr>
+                                                                        <td>
+                                                                            <a style="margin-right: 2px"
+                                                                               class="btn btn-primary btn-default active"
+                                                                               href="https://unite.un.org/sites/unite.un.org/files/app-desa-atlantis/index.html"
+                                                                               role="button">Explore</a>
+                                                                        </td>
+                                                                        <td>
+                                                                            <a class="btn btn-default "
+                                                                               href="https://github.com/UN-DESA-Modelling/Atlantis"
+                                                                               role="button">Supplementary Materials</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="https://unite.un.org/sites/unite.un.org/files/app-desa-atlantis/index.html"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/atlantis_banner_2.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-2dbc6662-707f-4a24-a07a-a5ce2e3e908b pane-bundle-text">
+
+                                    <h2 class="pane-title">
+                                        SOCIAL </h2>
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="jumbotron" id="social">
+                                                            <h2>Microsimulation</h2>
+                                                            <p>Understanding the impact of policies and shocks at the
+                                                                detailed level of households and individuals is key for
+                                                                the formulation of development policies. A number of
+                                                                methodologies have been used in many countries. Some
+                                                                methodologies, for example, use sector employment
+                                                                impacts derived from economy-wide simulations to
+                                                                estimate changes in income in households and make them
+                                                                suitable to analysis by gender, area of residence and
+                                                                other sociodemographic indicators. Other micro
+                                                                simulation exercises directly impose the expected
+                                                                effects of policies and shocks on the relevant variables
+                                                                in household surveys and administrative data to draw
+                                                                detailed pictures of their effects.
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-7962f0ad-333d-494e-96b2-0e3b316ff925 pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Growth and Social Inclusion</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:50px"
+                                                                   align="justify">An economy-wide model probes into the
+                                                                    links between projected rapid growth and the
+                                                                    achievement of education, health and sanitation
+                                                                    goals. Simulations suggest that economic growth
+                                                                    greatly facilitates the achievement of social goals
+                                                                    and that in its absence the financial burden of
+                                                                    policies increases dramatically. A complementary
+                                                                    microsimulation exercise traces their effects on
+                                                                    poverty and income distribution.</p>
+                                                                <!-- <a class="btn btn-primary btn-default active" href="#" role="button">Explore</a> -->
+                                                                <p>
+                                                                    <!-- <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/Growth_and_Social_Inclusion_focus_INEQUALITY" role="button">Supplementary Materials</a> --></p>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail" href="#"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/focus_povertybanner_0.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-63dd1aaa-045b-4548-a351-26f8d4d4388c pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Estimating Electricity Consumption from Household
+                                                                    Surveys</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:25px"
+                                                                   align="justify">Estimating the demand for electricity
+                                                                    is a critical step in the design of a medium to long
+                                                                    term energy plan. Frequently, estimates are based on
+                                                                    time series with few observation points or on data
+                                                                    from other countries or regions. Microsimulation
+                                                                    models use household surveys to offer an alternative
+                                                                    estimation route based on observed electricity
+                                                                    demand by households with different incomes.</p>
+                                                                <!-- <a class="btn btn-primary btn-default active" href="#" role="button">Explore</a> -->
+                                                                <p><a class="btn btn-default active"
+                                                                      href="https://github.com/UN-DESA-Modelling/Electricity_Consumption_Surveys"
+                                                                      role="button">Supplementary Materials</a></p>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="https://github.com/UN-DESA-Modelling/Electricity_Consumption_Surveys"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/electricity_banner_2.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-8405dd15-3315-42c7-9e50-8e1087d69553 pane-bundle-text">
+
+                                    <h2 class="pane-title">
+                                        ENVIRONMENT </h2>
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="jumbotron" id="environmental">
+                                                            <p>Understanding the physical, technical and economic
+                                                                inter-linkages among critical elements of the
+                                                                environmental system is key to the formulation of
+                                                                sustainable development policies. Policies need to take
+                                                                into account the way water, land-use, food production,
+                                                                energy, and atmospheric conditions interact.
+                                                                Methodologies and modelling tools such as the Climate,
+                                                                Land, Energy and Water Strategies (CLEWS) and the Water,
+                                                                Food, Energy NEXUS help identify some of these
+                                                                trade-offs and synergies.</p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-7c757c72-c72f-4eba-aa44-a93fd409fb8d pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Climate, Land, Energy and Water systems: a Global
+                                                                    Model</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:25px"
+                                                                   align="justify">Analysing the relationship among
+                                                                    water, energy, land and climate at the global scale
+                                                                    can offer useful contextual information about the
+                                                                    challenges countries face while progressing towards
+                                                                    the Sustainable Development Goals. The Global CLEWS
+                                                                    model offers useful contextual information about the
+                                                                    inter-linkages among climate, land, energy and
+                                                                    water. Global model results, suggest, for example,
+                                                                    that limiting emissions below 2°C global warming
+                                                                    requires strong dampening of world energy demand
+                                                                    trends, as well as full-scale restructuring of the
+                                                                    global energy supply towards renewable sources. </p>
+                                                                <table>
+
+                                                                    <tr>
+                                                                        <td>
+                                                                            <a style="margin-right: 2px"
+                                                                               class="btn btn-primary btn-default active"
+                                                                               href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html"
+                                                                               role="button">Explore</a>
+                                                                        </td>
+                                                                        <td>
+                                                                            <a class="btn btn-default active"
+                                                                               href="https://github.com/UN-DESA-Modelling/CLEWS_Global"
+                                                                               role="button">Supplementary Materials</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/climate_banner_2.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-ef25431c-41b7-4ae3-b485-db78db6537a5 pane-bundle-text">
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even">
+                                                        <div class="row">
+                                                            <div class="col-xs-4">
+                                                                <h2>Climate, Land, Energy and Water Systems: a
+                                                                    Demonstration Model for Mauritius</h2>
+                                                                <p style="width:330%;margin-Bottom:10px; margin-Top:25px"
+                                                                   align="justify">Mauritius receives plentiful
+                                                                    rainfall, however the high population density of the
+                                                                    island puts pressure on water resources. The threat
+                                                                    of reduced precipitation as a result of climate
+                                                                    change is therefore a major concern. The Mauritius
+                                                                    government has demonstrated strong leadership in the
+                                                                    promotion of a broad range of renewable energy
+                                                                    sources, including ethanol. Increasing bio-fuels,
+                                                                    however, carries potentially important impacts on
+                                                                    the use of water and land.<br/><br/>
+                                                                    A CLEWS model of Mauritius explores how energy
+                                                                    policy, such as the promotion of renewable sources
+                                                                    of energy, can impact the use of water and land. A
+                                                                    key concern in this are the prospects for the sugar
+                                                                    industry, which to a large extent will determine the
+                                                                    future of land and water use. Results suggest that
+                                                                    boosting production of bio-fuels in pursuit of more
+                                                                    sustainable energy supply and national energy
+                                                                    security may compromise water security. The risk of
+                                                                    water scarcity worsens if climate change brings less
+                                                                    rainfall and higher temperatures to the
+                                                                    country.<br/><br/>
+                                                                    The modelling exercise sheds light on the
+                                                                    interlinkages across a number of SDGs. For example,
+                                                                    the attainment of SDG 7 (sustainable energy) may
+                                                                    have both positive and negative impacts on other
+                                                                    goals, such as SDG 2 (sustainable agriculture), SDG
+                                                                    6 (sustainable water management), SDG 8 (decent work
+                                                                    and economic growth), SDG 12 (responsible production
+                                                                    and consumption), SDG 13 (climate action) and SGD 15
+                                                                    (sustainable use of terrestrial ecosystems).</p>
+                                                                <table>
+                                                                    <tr>
+                                                                        <td>
+                                                                            <a style="margin-right: 2px"
+                                                                               class="btn btn-primary btn-default active"
+                                                                               href="https://unite.un.org/sites/unite.un.org/files/app-desa-mauritiusclews/index.html"
+                                                                               role="button">Explore</a>
+                                                                        </td>
+                                                                        <td>
+                                                                            <a class="btn btn-default active"
+                                                                               href="https://github.com/UN-DESA-Modelling/CLEWS_Mauritius"
+                                                                               role="button">Supplementary Materials</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </div>
+                                                            <div class="col-xs-3 "><a class="thumbnail"
+                                                                                      href="https://unite.un.org/sites/unite.un.org/files/app-desa-mauritiusclews/index.html"><img
+                                                                    alt="..." height="560"
+                                                                    src="images/climate2_banner_0.jpg" width="960"/></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                            </div>
+                        </div>
+                        <div class="moscone-flipped-column-content-region moscone-flipped-sidebar panel-panel span3">
+                            <div class="moscone-flipped-column-content-region-inner moscone-flipped-sidebar-inner panel-panel-inner">
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-b9cf91a5-83ec-4e25-b9d7-80c6bbdcb4b5 pane-bundle-text">
+
+                                    <h2 class="pane-title">
+                                        Resources </h2>
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even"><p>Download open source code and
+                                                        supplementary materials.</p>
+                                                        <p><a class="btn btn-default"
+                                                              href="https://github.com/UN-DESA-Modelling" role="button">Supplementary
+                                                            Materials »</a></p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-da1b4257-9465-4862-aa9f-51ab6be9bcc4 pane-bundle-text">
+
+                                    <h2 class="pane-title">
+                                        About this site </h2>
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even"><p>This site is collaboratively
+                                                        developed by the <strong><a href="http://www.un.org/desa/en"
+                                                                                    target="_blank">Department of
+                                                            Economic and Social Affairs</a> </strong>and the <strong><a
+                                                                href="http://unite.un.org/analytics" target="_blank">Office
+                                                            of Information and Communications Technology</a></strong>.
+                                                    </p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                                <div class="panel-separator"></div>
+                                <div class="panel-pane pane-fieldable-panels-pane pane-uuid-c64edcda-8577-409a-a718-6d766ec2266e pane-bundle-text">
+
+                                    <h2 class="pane-title">
+                                        Partners </h2>
+
+
+                                    <div class="pane-content">
+                                        <div class="fieldable-panels-pane">
+                                            <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                                <div class="field-items">
+                                                    <div class="field-item even"><p><a href="http://www.iaea.org/"
+                                                                                       target="_blank">International
+                                                        Atomic Energy Agency</a></p>
+                                                        <p><a href="http://www.ipc-undp.org/" target="_blank">International
+                                                            Policy Centre for Inclusive Growth, Brazil</a></p>
+                                                        <p><a href="https://www.kth.se/en" target="_blank">KTH Royal
+                                                            Institute of Technology, Sweden</a></p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="moscone-container moscone-footer clearfix panel-panel row-fluid">
+                        <div class="moscone-container-inner moscone-footer-inner panel-panel-inner span12">
+                            <div class="panel-pane pane-fieldable-panels-pane pane-uuid-8e9f1c59-66bc-49f6-a542-98b383a74387 pane-bundle-text">
+
+
+                                <div class="pane-content">
+                                    <div class="fieldable-panels-pane">
+                                        <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden">
+                                            <div class="field-items">
+                                                <div class="field-item even">
+                                                    <style type="text/css">
+                                                        <!-- /*--><![CDATA[/* ><!--*/
+                                                        #navbar {
+                                                            display: none !important;
+                                                        }
+
+                                                        .breadcrumb {
+                                                            display: none !important
+                                                        }
+
+                                                        .panopoly-spotlight-buttons-wrapper {
+                                                            display: none !important
+                                                        }
+
+                                                        .page-header {
+                                                            display: none !important
+                                                        }
+
+                                                        #environment {
+                                                            background-color: blue;
+                                                        }
+
+                                                        .panopoly-spotlight-wrapper {
+                                                            display: none !important
+                                                        }
+
+                                                        .un-top {
+                                                            display: none;
+                                                        }
+
+                                                        img.panopoly-image-spotlight {
+                                                            width: 100%;
+                                                        }
+
+                                                        /*--><!]]>*/
+                                                    </style>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+
+                            </div>
+                        </div>
+                    </div>
+
+            </div><!-- /.moscone-flipped -->
+
+        </section> <!-- /.block -->
     </div>
-  </div>
-
-  <div class="moscone-flipped-container moscone-flipped-column-content clearfix row-fluid">
-    <div class="moscone-flipped-column-content-region moscone-flipped-content panel-panel span9">
-      <div class="moscone-flipped-column-content-region-inner moscone-flipped-content-inner panel-panel-inner">
-        <div class="panel-pane pane-fieldable-panels-pane pane-uuid-d902456b-f917-480b-8578-46d26ee9105d pane-bundle-text"  >
-  
-        <h2 class="pane-title">
-      Economy    </h2>
-    
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="jumbotron" id="economy">
-<p>Assessing the economic impact of policies and shocks.</p>
-<h2>Economy-wide modelling</h2>
-<p>Development policy must address the way policies and economic shocks affect multiple variables such as public budgets, the external sector, economic activity and employment in sectors, poverty and inequality. Economy-wide models are useful tools to investigate these effects.</p>
-</div>
-</div></div></div></div>
-  </div>
-
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-38440fa1-db36-4da9-bcd7-b263be56ff1e pane-bundle-text"  >
-  
-      
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-
-  <!--<a class="thumbnail" style="margin:auto;" href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img alt="..."  height="560" width="960" src="images/fuel_banner_6.jpg" /></a>--></div>
-<div class="col-xs-4" align="left">
-<h2 style="margin-bottom: 10px;margin-top: 20px">Fuel Tax and Development</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:47px" align="justify">A simulation of a fuel tax, a proxy for a carbon tax, in three developing countries shows differential impacts on GDP and in a set of key social indicators. Results suggest impacts depend not only on how the newly tax revenue is recycled back to the economy, but also on how differences in structural factors condition responses in countries. Results confirm that policy choices must be assessed on the basis of the specific characteristics and objectives of each country and that policies are not easily transferable across countries.</p>
-<p><a class="btn btn-primary btn-default active" href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html" role="button">Explore</a> <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/Fuel_Tax_and_Development" role="button">Supplementary Materials</a></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="https://unite.un.org/sites/unite.un.org/files/app-desa-fueltax/index.html"><img alt="..." height="560" src="images/fuel_banner_6.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-89dc2c29-1407-419d-8611-619e96e16ce1 pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Universal Access to Electricity</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:50px" align="justify">Providing universal access to electricity by 2030 poses challenges to many countries and calls for a careful selection of technologies. Using open geo-spatial data this model estimates the mix of technologies that will provide universal access at the lowest cost. The model assesses ten scenarios defined by two prices for diesel and five consumption levels. Results for 44 African countries suggest that GRID connections could supply up to 76 percent of the electricity needs of the population in some scenarios. Other scenarios give preference to small scale renewable sources, which could supply up to 41 percent of electricity needs. The investment cost to reach universality averages around 350 US dollars per person, but it can add to 1,000 US dollars and more per person in several countries.</p>
-<p><a class="btn btn-primary btn-default active" href="http://un-desa-modelling.github.io/Electrification_Paths/index.html" role="button" style="float: left" type="image">Explore</a> <a class="btn btn-default pull-right active" href="https://github.com/UN-DESA-Modelling/Electrification_Paths" role="button" >Supplementary Materials</a></p>
-
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="http://un-desa-modelling.github.io/Electrification_Paths/index.html"><img alt="..." height="560" src="images/electrification_banner_19.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-e24f16eb-02ab-42b8-9a13-0a040422255a pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Atlantis, Integrated Systems Analysis of Energy</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:25px" align="justify">Building local energy-planning capacity in countries can greatly benefit from an open, accessible, transferable, yet powerful modelling package. UN DESA, in partnership with KTH-dESA, has piloted capacity development in selected countries to support country efforts in medium-long term energy planning and it is now initiating projects in new countries. These projects preferentially use the Open Source Energy Modelling System model (OSeMOSYS), a powerful yet open, flexible and transferable tool. To further facilitate capacity development and model improvement, UN DESA and KTH-dESA have developed a browser based interface for OSeMOSYS, the Model Management Infrastructure (MoManI). MoManI can provide development and energy planners with the tools required to construct models, explore scenarios and visualize results.</p>
-<p><a class="btn btn-primary btn-default active" href="https://unite.un.org/sites/unite.un.org/files/app-desa-atlantis/index.html" role="button">Explore</a> <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/Atlantis" role="button">Supplementary Materials</a></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="https://unite.un.org/sites/unite.un.org/files/app-desa-atlantis/index.html"><img alt="..." height="560" src="images/atlantis_banner_2.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-2dbc6662-707f-4a24-a07a-a5ce2e3e908b pane-bundle-text"  >
-
-        <h2 class="pane-title">
-      SOCIAL    </h2>
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="jumbotron" id="social">
-<h2>Microsimulation</h2>
-<p>Understanding the impact of policies and shocks at the detailed level of households and individuals is key for the formulation of development policies. A number of methodologies have been used in many countries. Some methodologies, for example, use sector employment impacts derived from economy-wide simulations to estimate changes in income in households and make them suitable to analysis by gender, area of residence and other sociodemographic indicators. Other micro simulation exercises directly impose the expected effects of policies and shocks on the relevant variables in household surveys and administrative data to draw detailed pictures of their effects.
-</p>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-7962f0ad-333d-494e-96b2-0e3b316ff925 pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Growth and Social Inclusion</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:50px" align="justify">An economy-wide model probes into the links between projected rapid growth and the achievement of education, health and sanitation goals. Simulations suggest that economic growth greatly facilitates the achievement of social goals and that in its absence the financial burden of policies increases dramatically. A complementary microsimulation exercise traces their effects on poverty and income distribution.</p>
-<!-- <a class="btn btn-primary btn-default active" href="#" role="button">Explore</a> --><p>
-<!-- <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/Growth_and_Social_Inclusion_focus_INEQUALITY" role="button">Supplementary Materials</a> --></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="#"><img alt="..." height="560" src="images/focus_povertybanner_0.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-63dd1aaa-045b-4548-a351-26f8d4d4388c pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Estimating Electricity Consumption from Household Surveys</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:25px" align="justify">Estimating the demand for electricity is a critical step in the design of a medium to long term energy plan. Frequently, estimates are based on time series with few observation points or on data from other countries or regions. Microsimulation models use household surveys to offer an alternative estimation route based on observed electricity demand by households with different incomes.</p>
-<!-- <a class="btn btn-primary btn-default active" href="#" role="button">Explore</a> --><p><a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/Electricity_Consumption_Surveys" role="button">Supplementary Materials</a></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="https://github.com/UN-DESA-Modelling/Electricity_Consumption_Surveys"><img alt="..." height="560" src="images/electricity_banner_2.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-8405dd15-3315-42c7-9e50-8e1087d69553 pane-bundle-text"  >
-
-        <h2 class="pane-title">
-      ENVIRONMENT    </h2>
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="jumbotron" id="environmental">
-<p>Understanding the physical, technical and economic inter-linkages among critical elements of the environmental system is key to the formulation of sustainable development policies. Policies need to take into account the way water, land-use, food production, energy, and atmospheric conditions interact. Methodologies and modelling tools such as the Climate, Land, Energy and Water Strategies (CLEWS) and the Water, Food, Energy NEXUS help identify some of these trade-offs and synergies.</p>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-7c757c72-c72f-4eba-aa44-a93fd409fb8d pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Climate, Land, Energy and Water systems: a Global Model</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:25px" align="justify">Analysing the relationship among water, energy, land and climate at the global scale can offer useful contextual information about the challenges countries face while progressing towards the Sustainable Development Goals. The Global CLEWS model offers useful contextual information about the inter-linkages among climate, land, energy and water. Global model results, suggest, for example, that limiting emissions below 2°C global warming requires strong dampening of world energy demand trends, as well as full-scale restructuring of the global energy supply towards renewable sources. </p>
-<p><a class="btn btn-primary btn-default active" href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html" role="button">Explore</a> <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/CLEWS_Global" role="button">Supplementary Materials</a></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="https://unite.un.org/sites/unite.un.org/files/app-globalclews-v-1-0/landingpage.html"><img alt="..." height="560" src="images/climate_banner_2.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-ef25431c-41b7-4ae3-b485-db78db6537a5 pane-bundle-text"  >
-
-
-
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><div class="row">
-<div class="col-xs-4">
-<h2>Climate, Land, Energy and Water Systems: a Demonstration Model for Mauritius</h2>
-<p style="width:330%;margin-Bottom:10px; margin-Top:25px" align="justify">Mauritius receives plentiful rainfall, however the high population density of the island puts pressure on water resources. The threat of reduced precipitation as a result of climate change is therefore a major concern. The Mauritius government has demonstrated strong leadership in the promotion of a broad range of renewable energy sources, including ethanol. Increasing bio-fuels, however, carries potentially important impacts on the use of water and land.<br /><br/>
-A CLEWS model of Mauritius explores how energy policy, such as the promotion of renewable sources of energy, can impact the use of water and land. A key concern in this are the prospects for the sugar industry, which to a large extent will determine the future of land and water use. Results suggest that boosting production of bio-fuels in pursuit of more sustainable energy supply and national energy security may compromise water security. The risk of water scarcity worsens if climate change brings less rainfall and higher temperatures to the country.<br /><br/>
-The modelling exercise sheds light on the interlinkages across a number of SDGs. For example, the attainment of SDG 7 (sustainable energy) may have both positive and negative impacts on other goals, such as SDG 2 (sustainable agriculture), SDG 6 (sustainable water management), SDG 8 (decent work and economic growth), SDG 12 (responsible production and consumption), SDG 13 (climate action) and SGD 15 (sustainable use of terrestrial ecosystems).</p>
-<p><a class="btn btn-primary btn-default active" href="https://unite.un.org/sites/unite.un.org/files/app-desa-mauritiusclews/index.html" role="button">Explore</a> <a class="btn btn-default active" href="https://github.com/UN-DESA-Modelling/CLEWS_Mauritius" role="button">Supplementary Materials</a></p>
-</div>
-<div class="col-xs-3 "><a class="thumbnail" href="https://unite.un.org/sites/unite.un.org/files/app-desa-mauritiusclews/index.html"><img alt="..." height="560" src="images/climate2_banner_0.jpg" width="960" /></a></div>
-</div>
-</div></div></div></div>
-  </div>
-
-  
-  </div>
-      </div>
-    </div>
-    <div class="moscone-flipped-column-content-region moscone-flipped-sidebar panel-panel span3">
-      <div class="moscone-flipped-column-content-region-inner moscone-flipped-sidebar-inner panel-panel-inner">
-        <div class="panel-pane pane-fieldable-panels-pane pane-uuid-b9cf91a5-83ec-4e25-b9d7-80c6bbdcb4b5 pane-bundle-text"  >
-  
-        <h2 class="pane-title">
-      Resources    </h2>
-    
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p>Download open source code and supplementary materials.</p>
-<p><a class="btn btn-default" href="https://github.com/UN-DESA-Modelling" role="button">Supplementary Materials »</a></p>
-</div></div></div></div>
-  </div>
-
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-da1b4257-9465-4862-aa9f-51ab6be9bcc4 pane-bundle-text"  >
-  
-        <h2 class="pane-title">
-      About this site    </h2>
-    
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p>This site is collaboratively developed by the <strong><a href="http://www.un.org/desa/en" target="_blank">Department of Economic and Social Affairs</a> </strong>and the <strong><a href="http://unite.un.org/analytics" target="_blank">Office of Information and Communications Technology</a></strong>.</p>
-</div></div></div></div>
-  </div>
-
-  
-  </div>
-<div class="panel-separator"></div><div class="panel-pane pane-fieldable-panels-pane pane-uuid-c64edcda-8577-409a-a718-6d766ec2266e pane-bundle-text"  >
-  
-        <h2 class="pane-title">
-      Partners    </h2>
-    
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p><a href="http://www.iaea.org/" target="_blank">International Atomic Energy Agency</a></p>
-<p><a href="http://www.ipc-undp.org/" target="_blank">International Policy Centre for Inclusive Growth, Brazil</a></p>
-<p><a href="https://www.kth.se/en" target="_blank">KTH Royal Institute of Technology, Sweden</a></p>
-</div></div></div></div>
-  </div>
-
-  
-  </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="moscone-container moscone-footer clearfix panel-panel row-fluid">
-    <div class="moscone-container-inner moscone-footer-inner panel-panel-inner span12">
-      <div class="panel-pane pane-fieldable-panels-pane pane-uuid-8e9f1c59-66bc-49f6-a542-98b383a74387 pane-bundle-text"  >
-  
-      
-  
-  <div class="pane-content">
-    <div class="fieldable-panels-pane">
-    <div class="field field-name-field-basic-text-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><style type="text/css">
-<!--/*--><![CDATA[/* ><!--*/
-#navbar { display:none !important; }
-.breadcrumb {display:none !important}
-.panopoly-spotlight-buttons-wrapper {display:none !important}
-.page-header {display:none !important}
-#environment { background-color: blue; }
-.panopoly-spotlight-wrapper  {display:none !important}
-
-.un-top {display: none;}
-
-img.panopoly-image-spotlight {
-    width: 100%;
-}
-
-/*--><!]]>*/
-</style></div></div></div></div>
-  </div>
-
-  
-  </div>
-    </div>
-  </div>
-
-</div><!-- /.moscone-flipped -->
-
-</section> <!-- /.block -->
-  </div>
     </section>
 
-    
-  </div>
+
+</div>
 </div>
 <footer class="footer container">
     <div class="region region-footer">
-    <section id="block-block-4" class="block block-block clearfix">
-
-      
-  <p><img alt="" src="images/oict_footer.png" width="370" height="32" /></p>
-
-</section> <!-- /.block -->
-<section id="block-block-1" class="block block-block clearfix">
-
-      
-  <ul>
-<li><a href="http://www.un.org/en/aboutun/copyright/">Copyright</a></li>
-<li><a href="http://www.un.org/en/aboutun/terms/">Terms of Use</a></li>
-<li><a href="http://www.un.org/en/aboutun/privacy/">Privacy Notice</a></li>
-<li class="last"><a href="http://www.un.org/en/aboutun/fraudalert/">Fraud Alert</a></li>
-</ul>
-
-</section> <!-- /.block -->
-<section id="block-block-7" class="block block-block clearfix">
-
-      
-  <style type="text/css">
-<!--/*--><![CDATA[/* ><!--*/
-body {
-	font-size: 15px;
-}
-
-#menu-9144-1 .sf-depth-1 {
-   pointer-events: none;
-   cursor: default;
-}
-
-.breadcrumb a:visited {
-    color: #A2DDF9;
-}
-
-#panels-ipe-paneid-835 h2 {
-      background: url("https://unite.un.org/sites/unite.un.org/files/alert.png") 0 center no-repeat;
-  padding-left: 32px; 
-}
-
-#panels-ipe-paneid-835 a {
-color: #f1635C
-}
+        <section id="block-block-4" class="block block-block clearfix">
 
 
-#panels-ipe-paneid-835 h2 {
-    border-bottom: none;}
+            <p><img alt="" src="images/oict_footer.png" width="370" height="32"/></p>
 
-#navbar #block-search-form {
-	visibility:hidden;
-}
-
-#navbar #block-search-form {
-	margin: 36px 0 0 0;
-}
+        </section> <!-- /.block -->
+        <section id="block-block-1" class="block block-block clearfix">
 
 
-.view h3 {
-	font-size: 23px;
-}
-.socialmedia {
-	float: right;
-	margin: 5px 0 0 0;
-}
-.socialmedia li{
-	background-color: #f79422;
-	display: inline-block;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
-	border-radius: 3px;
-	list-style: none;
-	width: 30px;
-	height: 30px;
-}
-.socialmedia li a {
-	text-indent: -9999px;
-	display: inline-block;
-	width: 30px;
-	height: 30px;
-}
+            <ul>
+                <li><a href="http://www.un.org/en/aboutun/copyright/">Copyright</a></li>
+                <li><a href="http://www.un.org/en/aboutun/terms/">Terms of Use</a></li>
+                <li><a href="http://www.un.org/en/aboutun/privacy/">Privacy Notice</a></li>
+                <li class="last"><a href="http://www.un.org/en/aboutun/fraudalert/">Fraud Alert</a></li>
+            </ul>
 
-.socialmedia li:hover{
-	opacity:.9;
-	-moz-transform:rotate(360deg);
-	-webkit-transform:rotate(360deg);
-	-webkit-transition:all 0.7s ease 0s;
-	-moz-transition:all 0.7s ease 0s;
-	-o-transition:all 0.7s ease 0s;
-	transition:all 0.7s ease 0s;
-	background-color: #67aedf;
-}
-
-.facebook{
-	background-image: url(/sites/unite.un.org/files/facebook.png);
-}
-.twitter{
-	background-image: url(/sites/unite.un.org/files/twitter.png);
-}
-.googleplus{
-	background-image: url(/sites/unite.un.org/files/googleplus.png);
-}
-.youtube{
-	background-image: url(images/youtube.png);
-}
-.view-services.view-id-services .view-content {
-    display: flex; 
-    flex-wrap: wrap;
-}
-.view-services.view-id-services .views-row {
-	margin: 0 1% 10px 0;
-	width: 24%;
-	/*
-background: #1B75BB;
-	color: #fff;
-*/
-	position: relative;
-	padding-bottom: 40px !important;
-}
-.views-field-field-service-logo img {
-    height: 100px;
-    width: auto;
-}
-.views-field-field-service-logo {
-    background: #6998C9;
-    text-align: center;
-    padding: 10px 0;
-    border-radius: 3px;
-    margin-bottom: 10px;
-}
-.views-field-field-service-logo-home {
-    background: none;
-    text-align: center;
-    padding: 10px 0;
-    border-radius: 3px;
-    margin-bottom: -5px;
-}
-.views-field-field-service-url, .views-field-field-service-learn-more{
-	position: absolute;
-	bottom: 4px;
-    background: #1B75BB;
-    padding: 5px 8px;
-    width: 50%;
-	text-align: center
-}
-.views-field-field-service-url {
-    left: 4px;
-    border-right: 1px solid #FFFFFF;
-    border-radius: 3px 0 0 3px;
-}
-
-.views-field-field-service-learn-more {
-    right: 4px;
-    border-left: 1px solid #FFFFFF;
-    border-radius: 0 3px 3px 0;
-}
-.views-field-field-service-url a, .views-field-field-service-learn-more a {
-    color: #fff;
-}
-.pane-content li {
-    list-style: inherit;
-    border: 0;
-}
-
-ul {
-    padding: 0 0 0 20px;
-}
-
-.rtc-table tr:nth-child(even) {background: #FFF;}
-.rtc-table tr:nth-child(odd) {background: #E6E9F2;}
-.rtc-table th {background: #CFCFD0; padding: 5px;}
-.rtc-table td {padding: 5px;}
+        </section> <!-- /.block -->
+        <section id="block-block-7" class="block block-block clearfix">
 
 
+            <style type="text/css">
+                <!-- /*--><![CDATA[/* ><!--*/
+                body {
+                    font-size: 15px;
+                }
+
+                #menu-9144-1 .sf-depth-1 {
+                    pointer-events: none;
+                    cursor: default;
+                }
+
+                .breadcrumb a:visited {
+                    color: #A2DDF9;
+                }
+
+                #panels-ipe-paneid-835 h2 {
+                    background: url("https://unite.un.org/sites/unite.un.org/files/alert.png") 0 center no-repeat;
+                    padding-left: 32px;
+                }
+
+                #panels-ipe-paneid-835 a {
+                    color: #f1635C
+                }
+
+                #panels-ipe-paneid-835 h2 {
+                    border-bottom: none;
+                }
+
+                #navbar #block-search-form {
+                    visibility: hidden;
+                }
+
+                #navbar #block-search-form {
+                    margin: 36px 0 0 0;
+                }
+
+                .view h3 {
+                    font-size: 23px;
+                }
+
+                .socialmedia {
+                    float: right;
+                    margin: 5px 0 0 0;
+                }
+
+                .socialmedia li {
+                    background-color: #f79422;
+                    display: inline-block;
+                    -webkit-border-radius: 3px;
+                    -moz-border-radius: 3px;
+                    border-radius: 3px;
+                    list-style: none;
+                    width: 30px;
+                    height: 30px;
+                }
+
+                .socialmedia li a {
+                    text-indent: -9999px;
+                    display: inline-block;
+                    width: 30px;
+                    height: 30px;
+                }
+
+                .socialmedia li:hover {
+                    opacity: .9;
+                    -moz-transform: rotate(360deg);
+                    -webkit-transform: rotate(360deg);
+                    -webkit-transition: all 0.7s ease 0s;
+                    -moz-transition: all 0.7s ease 0s;
+                    -o-transition: all 0.7s ease 0s;
+                    transition: all 0.7s ease 0s;
+                    background-color: #67aedf;
+                }
+
+                .facebook {
+                    background-image: url(/sites/unite.un.org/files/facebook.png);
+                }
+
+                .twitter {
+                    background-image: url(/sites/unite.un.org/files/twitter.png);
+                }
+
+                .googleplus {
+                    background-image: url(/sites/unite.un.org/files/googleplus.png);
+                }
+
+                .youtube {
+                    background-image: url(images/youtube.png);
+                }
+
+                .view-services.view-id-services .view-content {
+                    display: flex;
+                    flex-wrap: wrap;
+                }
+
+                .view-services.view-id-services .views-row {
+                    margin: 0 1% 10px 0;
+                    width: 24%;
+                    /*
+                background: #1B75BB;
+                    color: #fff;
+                */
+                    position: relative;
+                    padding-bottom: 40px !important;
+                }
+
+                .views-field-field-service-logo img {
+                    height: 100px;
+                    width: auto;
+                }
+
+                .views-field-field-service-logo {
+                    background: #6998C9;
+                    text-align: center;
+                    padding: 10px 0;
+                    border-radius: 3px;
+                    margin-bottom: 10px;
+                }
+
+                .views-field-field-service-logo-home {
+                    background: none;
+                    text-align: center;
+                    padding: 10px 0;
+                    border-radius: 3px;
+                    margin-bottom: -5px;
+                }
+
+                .views-field-field-service-url, .views-field-field-service-learn-more {
+                    position: absolute;
+                    bottom: 4px;
+                    background: #1B75BB;
+                    padding: 5px 8px;
+                    width: 50%;
+                    text-align: center
+                }
+
+                .views-field-field-service-url {
+                    left: 4px;
+                    border-right: 1px solid #FFFFFF;
+                    border-radius: 3px 0 0 3px;
+                }
+
+                .views-field-field-service-learn-more {
+                    right: 4px;
+                    border-left: 1px solid #FFFFFF;
+                    border-radius: 0 3px 3px 0;
+                }
+
+                .views-field-field-service-url a, .views-field-field-service-learn-more a {
+                    color: #fff;
+                }
+
+                .pane-content li {
+                    list-style: inherit;
+                    border: 0;
+                }
+
+                ul {
+                    padding: 0 0 0 20px;
+                }
+
+                .rtc-table tr:nth-child(even) {
+                    background: #FFF;
+                }
+
+                .rtc-table tr:nth-child(odd) {
+                    background: #E6E9F2;
+                }
+
+                .rtc-table th {
+                    background: #CFCFD0;
+                    padding: 5px;
+                }
+
+                .rtc-table td {
+                    padding: 5px;
+                }
+
+                .front.i18n-es .col-sm-12, .front.i18n-ar .col-sm-12, .front.i18n-zh-hans .col-sm-12, .front.i18n-fr .col-sm-12, .front.i18n-ru .col-sm-12 {
+                    background: #fff;
+                    padding: 15px;
+                }
+
+                .main-container.container {
+                    width: 100%;
+                    background: -webkit-linear-gradient(#183249 0%, #184864 100%);
+                    background: -moz-linear-gradient(#183249 0%, #184864 100%);
+                    background: -o-linear-gradient(#183249 0%, #184864 100%);
+                    background: -ms-linear-gradient(#183249 0%, #184864 100%);
+                    background-color: #183249;
+                    border-top: 5px solid #2AA8E0;
+                }
+
+                .main-container.container .row {
+                    max-width: 1170px;
+                    margin: 0 auto;
+                }
+
+                header#navbar {
+                    margin-bottom: 0;
+                }
+
+                nav.navigation {
+                    border: 0;
+                    background: #2aa8e0;
+                }
+
+                #navbar .navigation .sf-menu.sf-horizontal.sf-shadow ul {
+                    background: #283050;
+                }
+
+                h1.page-header {
+                    display: none;
+                }
+
+                .front .moscone-flipped-container.moscone-flipped-column-content {
+                    background: #fff;
+                    border-bottom: 15px solid #2AA8E0;
+                    margin: 0;
+                    padding: 50px;
+                }
+
+                .moscone-flipped-content-inner, .bryant-flipped-content-inner, .burr-flipped-content-inner {
+                    margin-right: 60px;
+                }
+
+                footer.footer.container {
+                    width: 100%;
+                    margin: 0;
+                    background: #F79422;
+                    border: 0;
+                    padding: 10px;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 {
+                    text-align: center;
+                    margin: 0;
+                    padding: 30px 0 50px 0;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4.active {
+                    background: #22a9e3;
+                    color: #fff;
+                    padding: 30px 0 52px 0;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 h2 {
+                    color: #fff;
+                    font-weight: 700;
+                    font-size: 29px;
+                    padding: 50px;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 a:after {
+                    display: inline-block;
+                    font: normal normal normal 14px/1 FontAwesome;
+                    font-size: inherit;
+                    text-rendering: auto;
+                    -webkit-font-smoothing: antialiased;
+                    -moz-osx-font-smoothing: grayscale;
+                    content: "\f067";
+                    display: block;
+                    margin-top: 50px;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4.active:after {
+                    width: 0;
+                    height: 0;
+                    border-left: 30px solid transparent;
+                    border-right: 30px solid transparent;
+                    border-top: 30px solid #22A9E3;
+                    content: '';
+                    position: absolute;
+                    bottom: -30px;
+                    left: 43%;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 img {
+                    display: block;
+                    margin: 0 auto;
+                }
+
+                .front .view-services.view-id-services {
+                    margin: 0 -60px 0 0px;
+                }
+
+                .front .view-services.view-id-services .views-row {
+                    width: 15%;
+                    padding-bottom: 0 !important;
+                    background: transparent;
+                    border: 0;
+                    text-align: center;
+                    box-shadow: 0 0 0;
+                }
+
+                .front .view-services.view-id-services .views-row a {
+                    color: #2AA8E0;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4.active a, .moscone-container.moscone-footer .nav-tabs > li > a:hover {
+                    background: transparent;
+                    border: 0;
+                    border-radius: 0;
+                    color: #fff;
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 a {
+                    font-size: 28px;
+                    color: #fff;
+                    font-weight: 900;
+                }
+
+                div#news .views-row, div#events .views-row {
+                    width: 33%;
+                    display: table-cell;
+                    padding-right: 40px;
+                    border: 0;
+                }
+
+                div#news .views-row a, div#events .views-row a {
+                    color: #22a9e3;
+                    font-weight: 600;
+                }
+
+                .front .tab-content {
+                    background: #fff;
+                    padding: 60px 15px;
+                }
+
+                .region.region-footer {
+                    max-width: 1170px;
+                    margin: 0 auto;
+                }
+
+                footer.footer.container .block {
+                    display: inline-block;
+                }
+
+                section#block-block-10 {
+                    float: right;
+                    margin-top: 5px;
+                }
+
+                section#block-block-10 li {
+                    border: 0;
+                }
+
+                section#block-block-1 a {
+                    color: #fff;
+                }
+
+                section#block-block-4 {
+                    float: left;
+                    margin-top: 10px;
+                }
+
+                section#block-block-1 {
+                    margin-top: 15px;
+                }
+
+                .not-front #block-system-main {
+                    background: #fff;
+                    padding: 50px;
+                }
+
+                ol.breadcrumb {
+                    background: transparent;
+                    color: #fff;
+                }
+
+                #flexslider-1 {
+                    box-shadow: 0 0 0 #000;
+                    background: transparent;
+                    border: 0;
+                    float: left;
+                    margin: 0;
+                }
+
+                ol.flex-control-nav.flex-control-thumbs {
+                    width: 300px;
+                    margin: 0;
+                    float: right;
+                }
+
+                #flexslider-1 li {
+                    width: 100%;
+                    margin-bottom: 1px;
+                    padding: 0;
+                }
+
+                #flexslider-1 ul.slides {
+                    margin-right: 301px;
+                }
+
+                #flexslider-1 ul:after {
+                    display: none;
+                }
+
+                #flexslider-1 .flex-control-nav li {
+                    height: 111.5px;
+                    overflow: hidden;
+                }
+
+                .node-type-event .span8 {
+                    background: rgba(0, 0, 0, 0);
+                    border: 0;
+                    margin: 0;
+                    padding: 0px !important;
+                }
+
+                @media (max-width: 768px) {
+                    ol.flex-control-nav.flex-control-thumbs {
+                        width: 100%;
+                    }
+
+                    #flexslider-1 .flex-control-nav li {
+                        width: 24%;
+                        margin-right: 1%;
+                    }
+
+                    .flexslider ul.slides {
+                        margin-right: 0;
+                        float: left;
+                    }
+
+                    #flexslider-1 ul.slides {
+                        width: 100%;
+                        margin: 0;
+                    }
+                }
+
+                .moscone-container.moscone-footer .col-sm-4 {
+                    width: 33%;
+                }
+
+                .front .view-services.view-id-services .views-row {
+                    width: 49%;
+                }
+
+                .front .view-services.view-id-services {
+                    margin: 0;
+                }
+
+                div#news .views-row, div#events .views-row {
+                    width: 100%;
+                    display: block;
+                }
+
+                #events table {
+                    margin: 0;
+                }
+
+                .moscone-flipped-content-inner, .bryant-flipped-content-inner, .burr-flipped-content-inner {
+                    margin: 0;
+                }
+
+                .front .moscone-flipped-container.moscone-flipped-column-content {
+                    padding: 20px;
+                }
+
+                #navbar .navigation a {
+                    border-right: 1px solid #35befb;
+                    padding: 5px 15px 10px 15px;
+                    margin-top: 5px;
+                }
+
+                #navbar .navigation a:hover {
+                    background: #3582a5;
+                    text-decoration: none;
+                }
+
+                /*--><!]]>*/
+            </style>
+        </section> <!-- /.block -->
+        <section id="block-block-10" class="block block-block clearfix">
 
 
+            <ul class="socialmedia">
+                <li class="facebook"><a href="http://www.facebook.com/UnitedNationsUnite">Facebook</a></li>
+                <li class="twitter"><a href="http://www.twitter.com/UN_CITO">Twitter</a></li>
+                <!--	<li class="googleplus"><a href="https://plus.google.com/118307866834627298491">Google+</a></li>-->
+            </ul>
+            <div style="display:none;"><a href="https://plus.google.com/118307866834627298491"
+                                          rel="publisher">Google+</a></div>
 
-.front.i18n-es .col-sm-12, .front.i18n-ar .col-sm-12, .front.i18n-zh-hans .col-sm-12, .front.i18n-fr .col-sm-12, .front.i18n-ru .col-sm-12 {
-    background: #fff;
-    padding: 15px;
-}
-.main-container.container {
-    width: 100%;
-    background: -webkit-linear-gradient(#183249 0%,#184864 100%);
-    background: -moz-linear-gradient(#183249 0%,#184864 100%);
-    background: -o-linear-gradient(#183249 0%,#184864 100%);
-    background: -ms-linear-gradient(#183249 0%,#184864 100%);
-    background-color: #183249;
-    border-top: 5px solid #2AA8E0;
-}
-
-.main-container.container .row {
-    max-width: 1170px;
-    margin: 0 auto;
-}
-
-header#navbar {
-    margin-bottom: 0;
-}
-
-nav.navigation {
-    border: 0;
-    background: #2aa8e0;
-}
-#navbar .navigation .sf-menu.sf-horizontal.sf-shadow ul {
-    background: #283050;
-}
-h1.page-header {
-    display: none;
-}
-
-.front .moscone-flipped-container.moscone-flipped-column-content {
-    background: #fff;
-    border-bottom: 15px solid #2AA8E0;
-    margin: 0;
-    padding: 50px;
-}
-
-.moscone-flipped-content-inner, .bryant-flipped-content-inner, .burr-flipped-content-inner {
-    margin-right: 60px;
- }
-
-footer.footer.container {
-    width: 100%;
-    margin: 0;
-    background: #F79422;
-    border: 0;
-    padding: 10px;
-}
-.moscone-container.moscone-footer .col-sm-4 {
-    text-align: center;
-    margin: 0;
-    padding: 30px 0 50px 0;
-}
-.moscone-container.moscone-footer .col-sm-4.active {
-    background: #22a9e3;
-    color: #fff;
-    padding: 30px 0 52px 0;
-}
-
-.moscone-container.moscone-footer .col-sm-4 h2 {
-    color: #fff;
-    font-weight: 700;
-    font-size: 29px;
-    padding: 50px;
-}
-.moscone-container.moscone-footer .col-sm-4 a:after {
-    display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    content: "\f067";
-    display: block;
-    margin-top: 50px;
-}
-
-
-.moscone-container.moscone-footer .col-sm-4.active:after {
-    width: 0;
-    height: 0;
-    border-left: 30px solid transparent;
-    border-right: 30px solid transparent;
-    border-top: 30px solid #22A9E3;
-    content: '';
-    position: absolute;
-    bottom: -30px;
-    left: 43%;
-}
-.moscone-container.moscone-footer .col-sm-4 img {
-    display: block;
-    margin: 0 auto;
-}
-.front .view-services.view-id-services {
-    margin: 0 -60px 0 0px;
-}
-.front .view-services.view-id-services .views-row {
-    width: 15%;
-    padding-bottom: 0 !important;
-    background: transparent;
-    border: 0;
-    text-align: center;
-        box-shadow: 0 0 0;
-}
-
-.front .view-services.view-id-services .views-row a {
-    color: #2AA8E0;
-}
-
-
-.moscone-container.moscone-footer .col-sm-4.active a, .moscone-container.moscone-footer .nav-tabs>li>a:hover {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-    color: #fff;
-}
-
-.moscone-container.moscone-footer .col-sm-4 a {
-    font-size: 28px;
-    color: #fff;
-    font-weight: 900;
-}
-div#news .views-row, div#events .views-row {
-    width: 33%;
-    display: table-cell;
-    padding-right: 40px;
-    border: 0;
-}
-
-div#news .views-row a,div#events .views-row a {
-    color: #22a9e3;
-    font-weight: 600;
-}
-
-.front .tab-content {
-    background: #fff;
-    padding: 60px 15px;
-}
-.region.region-footer {
-    max-width: 1170px;
-    margin: 0 auto;
-}
-
-footer.footer.container .block {
-    display: inline-block;
-}
-
-section#block-block-10 {
-    float: right;
-    margin-top: 5px;
-}
-
-section#block-block-10 li {
-    border: 0;
-}
-
-section#block-block-1 a {color: #fff;}
-
-section#block-block-4 {
-    float: left;
-    margin-top: 10px;
-}
-
-section#block-block-1 {
-    margin-top: 15px;
-}
-.not-front #block-system-main {
-    background: #fff;
-    padding: 50px;
-}
-
-ol.breadcrumb {
-    background: transparent;
-    color: #fff;
-}
-#flexslider-1 {
-    box-shadow: 0 0 0 #000;
-    background: transparent;
-    border: 0;
-    float: left;
-    margin: 0;
-}
-
-ol.flex-control-nav.flex-control-thumbs {
-    width: 300px;
-    margin: 0;
-    float: right;
-}
-#flexslider-1 li {
-    width: 100%;
-    margin-bottom: 1px;
-    padding: 0;
-}
-
-#flexslider-1 ul.slides {
-    margin-right: 301px;
-}
-
-#flexslider-1 ul:after {
-    display: none;
-}
-#flexslider-1 .flex-control-nav li {
-    height: 111.5px;
-    overflow: hidden;
-}
-
-.node-type-event .span8 {
-    background: rgba(0, 0, 0, 0);
-    border: 0;
-    margin: 0;
-    padding: 0px !important;
-}
-@media (max-width: 768px){
-    ol.flex-control-nav.flex-control-thumbs {
-        width: 100%;
-    }
-    #flexslider-1 .flex-control-nav li {
-        width: 24%;
-        margin-right: 1%;
-    }
-    
-    .flexslider ul.slides {
-        margin-right: 0;
-        float: left;
-    }
-    #flexslider-1 ul.slides {
-    width: 100%;
-    margin: 0;
-}
-}
-.moscone-container.moscone-footer .col-sm-4 {
-    width: 33%;
-}
-.front .view-services.view-id-services .views-row {
-    width: 49%;
-}
-.front .view-services.view-id-services {
-    margin: 0;
-}
-div#news .views-row, div#events .views-row {
-    width: 100%;
-    display: block;
-}
-#events table {
-    margin: 0;
-}
-.moscone-flipped-content-inner, .bryant-flipped-content-inner, .burr-flipped-content-inner {
-    margin: 0;
-}
-.front .moscone-flipped-container.moscone-flipped-column-content {
-    padding: 20px;
-}
-    #navbar .navigation a{
-    border-right: 1px solid #35befb;
-    padding: 5px 15px 10px 15px;
-    margin-top: 5px;
-}
-#navbar .navigation a:hover {
-    background: #3582a5;
-    text-decoration: none;
-}
-
-/*--><!]]>*/
-</style>
-</section> <!-- /.block -->
-<section id="block-block-10" class="block block-block clearfix">
-
-      
-  <ul class="socialmedia">
-<li class="facebook"><a href="http://www.facebook.com/UnitedNationsUnite">Facebook</a></li>
-<li class="twitter"><a href="http://www.twitter.com/UN_CITO">Twitter</a></li>
-<!--	<li class="googleplus"><a href="https://plus.google.com/118307866834627298491">Google+</a></li>--></ul>
-<div style="display:none;"><a href="https://plus.google.com/118307866834627298491" rel="publisher">Google+</a></div>
-
-</section> <!-- /.block -->
-  </div>
+        </section> <!-- /.block -->
+    </div>
 </footer>
-  <script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_widgets/panopoly-widgets.js?o7slkw"></script>
+<script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_widgets/panopoly-widgets.js?o7slkw"></script>
 <script src="https://unite.un.org/profiles/panopoly/modules/panopoly/panopoly_widgets/jquery-ui-tabs-rotate.js?o7slkw"></script>
 <script src="https://unite.un.org/profiles/panopoly/themes/bootstrap/js/bootstrap.js?o7slkw"></script>
 </body>


### PR DESCRIPTION
Currently the supplementary materials button looks like it is selected because it inherits from the active style sheet. By removing that inheritance, the button only turns grey when it is hovered over by a cursor.